### PR TITLE
Use memory patch to fix many player movement speed issues

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -28,7 +28,7 @@
 					"offset"	"979"
 				}
 			}
-			"Patch_Speedmedic2ClassCheck"
+			"Patch_SpeedMedic2ClassCheck"
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -172,17 +172,23 @@
 				"linux"		"@_ZN9CTFPlayer23GetEntityForLoadoutSlotEib"
 				"windows"	"\x55\x8B\xEC\x51\x53\x8B\x5D\x08\x57\x8B\xF9\x89\x7D\xFC\x83\xFB\x07"
 			}
-			"CTFGameStats::Event_PlayerFiredWeapon"
-			{
-				"library"	"server"
-				"linux"		"@_ZN12CTFGameStats23Event_PlayerFiredWeaponEP9CTFPlayerb"
-				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x56\x8B\x75\x08"
-			}
 			"CTFPlayer::TeamFortress_CalculateMaxSpeed"
 			{
 				"library"	"server"
 				"linux"		"@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x83\x3D\x2A\x2A\x2A\x2A\x00"
+			}
+			"CTFPlayerShared::InCond"
+			{
+				"library"	"server"
+				"linux"		"@_ZNK15CTFPlayerShared6InCondE7ETFCond"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x56\x57\x8B\x7D\x08\x8B\xF1\x83\xFF\x20"
+			}
+			"CTFGameStats::Event_PlayerFiredWeapon"
+			{
+				"library"	"server"
+				"linux"		"@_ZN12CTFGameStats23Event_PlayerFiredWeaponEP9CTFPlayerb"
+				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x56\x8B\x75\x08"
 			}
 		}
 		"Offsets"
@@ -329,6 +335,34 @@
 					"bool"
 					{
 						"type"	"bool"
+					}
+				}
+			}
+			"CTFPlayer::TeamFortress_CalculateMaxSpeed"
+			{
+				"signature"	"CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"callconv"	"thiscall"
+				"return"	"float"
+				"this"		"entity"
+				"arguments"
+				{
+					"ignoreCharging"
+					{
+						"type"	"bool"
+					}
+				}
+			}
+			"CTFPlayerShared::InCond"
+			{
+				"signature"	"CTFPlayerShared::InCond"
+				"callconv"	"thiscall"
+				"return"	"bool"
+				"this"		"address"
+				"arguments"
+				{
+					"nCond"
+					{
+						"type"	"int"
 					}
 				}
 			}

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -125,6 +125,10 @@
 				"linux"		"4"
 				"windows"	"4"
 			}
+			"DoWeHaveABetterWayOfGettingOS"
+			{
+				"linux"		"1"
+			}
 		}
 		"Functions"
 		{

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -4,12 +4,40 @@
 	{
 		"Addresses"
 		{
-			"CTFPlayer::TeamFortress_CalculateMaxSpeed::BFBCheck"
+			"Patch_HeavyClassCheck"
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"linux"
+				{
+					"offset"	"2141"
+				}
 				"windows"
 				{
-					"offset" "1519"
+					"offset"	"1436"
+				}
+			}
+			"Patch_SteakCondFailed"
+			{
+				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"linux"
+				{
+					"offset"	"3393"
+				}
+				"windows"
+				{
+					"offset"	"1467"
+				}
+			}
+			"Patch_SteakCondPassed"
+			{
+				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"linux"
+				{
+					"offset"	"3437"
+				}
+				"windows"
+				{
+					"offset"	"1504"
 				}
 			}
 		}
@@ -124,10 +152,6 @@
 			{
 				"linux"		"4"
 				"windows"	"4"
-			}
-			"DoWeHaveABetterWayOfGettingOS"
-			{
-				"linux"		"1"
 			}
 		}
 		"Functions"

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -2,6 +2,17 @@
 {
 	"tf"
 	{
+		"Addresses"
+		{
+			"CTFPlayer::TeamFortress_CalculateMaxSpeed::BFBCheck"
+			{
+				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"windows"
+				{
+					"offset" "1519"
+				}
+			}
+		}
 		"Signatures"
 		{
 			"CTFPlayer::GetMaxAmmo"
@@ -69,6 +80,12 @@
 				"library"	"server"
 				"linux"		"@_ZN12CTFGameStats23Event_PlayerFiredWeaponEP9CTFPlayerb"
 				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x56\x8B\x75\x08"
+			}
+			"CTFPlayer::TeamFortress_CalculateMaxSpeed"
+			{
+				"library"	"server"
+				"linux"		"@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x83\x3D\x2A\x2A\x2A\x2A\x00"
 			}
 		}
 		"Offsets"

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -4,7 +4,43 @@
 	{
 		"Addresses"
 		{
-			"Patch_HeavyClassCheck"
+			"Patch_SpeedDemomanClassCheck"
+			{
+				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"linux"
+				{
+					"offset"	"672"
+				}
+				"windows"
+				{
+					"offset"	"692"
+				}
+			}
+			"Patch_SpeedMedic1ClassCheck"
+			{
+				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"linux"
+				{
+					"offset"	"1173"
+				}
+				"windows"
+				{
+					"offset"	"979"
+				}
+			}
+			"Patch_Speedmedic2ClassCheck"
+			{
+				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
+				"linux"
+				{
+					"offset"	"1733"
+				}
+				"windows"
+				{
+					"offset"	"1270"
+				}
+			}
+			"Patch_SpeedHeavyClassCheck"
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -16,7 +52,7 @@
 					"offset"	"1436"
 				}
 			}
-			"Patch_SteakCondFailed"
+			"Patch_SpeedSteakCondFailed"
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -28,7 +64,7 @@
 					"offset"	"1467"
 				}
 			}
-			"Patch_SteakCondPassed"
+			"Patch_SpeedSteakCondPassed"
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -43,17 +79,32 @@
 		}
 		"Keys"
 		{
-			"Patch_HeavyClassCheck"
+			"Patch_SpeedDemomanClassCheck"
 			{
 				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
 				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
 			}
-			"Patch_SteakCondFailed"
+			"Patch_SpeedMedic1ClassCheck"
+			{
+				"linux"		"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to NOP (skip)
+				"windows"	"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to NOP (skip)
+			}
+			"Patch_SpeedMedic2ClassCheck"
+			{
+				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
+			}
+			"Patch_SpeedHeavyClassCheck"
+			{
+				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
+			}
+			"Patch_SpeedSteakCondFailed"
 			{
 				"linux"		"\x0F\x84\xC2\x00\x00\x00"	// Replace 'jz' location to 0xC2 (BFB check)
 				"windows"	"\x0F\x84\x30"	// Replace 'jz' location  to 0x30 (BFB check)
 			}
-			"Patch_SteakCondPassed"
+			"Patch_SpeedSteakCondPassed"
 			{
 				"linux"		"\xE9\x97\x00\x00\x00"	// Replace 'jmp' location to 0x97 (BFB check)
 				"windows"	"\xEB\x0F"	// Replace 'jbe' to 'jmp short' 0x0F (BFB check)

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -41,6 +41,24 @@
 				}
 			}
 		}
+		"Keys"
+		{
+			"Patch_HeavyClassCheck"
+			{
+				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
+			}
+			"Patch_SteakCondFailed"
+			{
+				"linux"		"\x0F\x84\xC2\x00\x00\x00"	// Replace 'jz' location to 0xC2 (BFB check)
+				"windows"	"\x0F\x84\x30"	// Replace 'jz' location  to 0x30 (BFB check)
+			}
+			"Patch_SteakCondPassed"
+			{
+				"linux"		"\xE9\x97\x00\x00\x00"	// Replace 'jmp' location to 0x97 (BFB check)
+				"windows"	"\xEB\x0F"	// Replace 'jbe' to 'jmp short' 0x0F (BFB check)
+			}
+		}
 		"Signatures"
 		{
 			"CTFPlayer::GetMaxAmmo"

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -189,6 +189,7 @@ int g_iClientWeaponIndex[TF_MAXPLAYERS+1][WeaponSlot_BuilderEngie+1];
 #include "randomizer/dhook.sp"
 #include "randomizer/sdkcall.sp"
 #include "randomizer/stocks.sp"
+#include "randomizer/patch.sp"
 
 public Plugin myinfo =
 {
@@ -208,23 +209,7 @@ public void OnPluginStart()
 	if (!hGameData)
 		SetFailState("Could not find randomizer gamedata");
 	
-	Address bup = hGameData.GetAddress("CTFPlayer::TeamFortress_CalculateMaxSpeed::BFBCheck");
-	//PrintToServer("%X: %X", bup+13, LoadFromAddress(bup+13, NumberType_Int8));
-	
-	// STEAK STUFF HERE
-	StoreToAddress(bup-83, 0x90, NumberType_Int8); // Die
-	StoreToAddress(bup-82, 0x90, NumberType_Int8); // Die
-	StoreToAddress(bup-50, 0x2B, NumberType_Int8); // Replace the JZ location
-	StoreToAddress(bup-14, 0xA, NumberType_Int8); // Replace the JZ location
-	StoreToAddress(bup-5, 0x90, NumberType_Int8); // Die
-	StoreToAddress(bup-4, 0x90, NumberType_Int8); // Die
-	
-	// BFB STUFF HERE
-	StoreToAddress(bup, 0x90, NumberType_Int8); // Die
-	StoreToAddress(bup+1, 0x90, NumberType_Int8); // Die
-	StoreToAddress(bup+13, 0x90, NumberType_Int8); // Die
-	StoreToAddress(bup+14, 0x90, NumberType_Int8); // Die
-	
+	Patch_Init(hGameData);
 	DHook_Init(hGameData);
 	SDKCall_Init(hGameData);
 	
@@ -259,6 +244,11 @@ public void OnPluginStart()
 		if (IsClientInGame(iClient))
 			OnClientPutInServer(iClient);
 	}
+}
+
+public void OnPluginEnd()
+{
+	Patch_ResetAll();
 }
 
 public void OnMapStart()

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -187,9 +187,9 @@ int g_iClientWeaponIndex[TF_MAXPLAYERS+1][WeaponSlot_BuilderEngie+1];
 #include "randomizer/ammo.sp"
 #include "randomizer/commands.sp"
 #include "randomizer/dhook.sp"
+#include "randomizer/patch.sp"
 #include "randomizer/sdkcall.sp"
 #include "randomizer/stocks.sp"
-#include "randomizer/patch.sp"
 
 public Plugin myinfo =
 {

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -208,6 +208,23 @@ public void OnPluginStart()
 	if (!hGameData)
 		SetFailState("Could not find randomizer gamedata");
 	
+	Address bup = hGameData.GetAddress("CTFPlayer::TeamFortress_CalculateMaxSpeed::BFBCheck");
+	//PrintToServer("%X: %X", bup+13, LoadFromAddress(bup+13, NumberType_Int8));
+	
+	// STEAK STUFF HERE
+	StoreToAddress(bup-83, 0x90, NumberType_Int8); // Die
+	StoreToAddress(bup-82, 0x90, NumberType_Int8); // Die
+	StoreToAddress(bup-50, 0x2B, NumberType_Int8); // Replace the JZ location
+	StoreToAddress(bup-14, 0xA, NumberType_Int8); // Replace the JZ location
+	StoreToAddress(bup-5, 0x90, NumberType_Int8); // Die
+	StoreToAddress(bup-4, 0x90, NumberType_Int8); // Die
+	
+	// BFB STUFF HERE
+	StoreToAddress(bup, 0x90, NumberType_Int8); // Die
+	StoreToAddress(bup+1, 0x90, NumberType_Int8); // Die
+	StoreToAddress(bup+13, 0x90, NumberType_Int8); // Die
+	StoreToAddress(bup+14, 0x90, NumberType_Int8); // Die
+	
 	DHook_Init(hGameData);
 	SDKCall_Init(hGameData);
 	

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -13,7 +13,7 @@ public void DHook_Init(GameData hGameData)
 {
 	DHook_CreateDetour(hGameData, "CTFPlayer::GetMaxAmmo", DHook_GetMaxAmmoPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::Taunt", DHook_TauntPre, DHook_TauntPost);
-	//DHook_CreateDetour(hGameData, "CTFPlayer::CanAirDash", _, DHook_CanAirDashPost);
+	DHook_CreateDetour(hGameData, "CTFPlayer::CanAirDash", _, DHook_CanAirDashPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::ValidateWeapons", DHook_ValidateWeaponsPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::DoClassSpecialSkill", DHook_DoClassSpecialSkillPre, DHook_DoClassSpecialSkillPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::GetChargeEffectBeingProvided", DHook_GetChargeEffectBeingProvidedPre, DHook_GetChargeEffectBeingProvidedPost);
@@ -148,6 +148,9 @@ public MRESReturn DHook_TauntPost(int iClient, Handle hParams)
 
 public MRESReturn DHook_CanAirDashPost(int iClient, Handle hReturn)
 {
+	if (iClient == -1)
+		return MRES_Ignored;
+	
 	//Soda Popper and Atomizer's extra jumps does not work for non-scouts, fix that
 	if (!DHookGetReturn(hReturn))
 	{

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -13,7 +13,7 @@ public void DHook_Init(GameData hGameData)
 {
 	DHook_CreateDetour(hGameData, "CTFPlayer::GetMaxAmmo", DHook_GetMaxAmmoPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::Taunt", DHook_TauntPre, DHook_TauntPost);
-	DHook_CreateDetour(hGameData, "CTFPlayer::CanAirDash", _, DHook_CanAirDashPost);
+	//DHook_CreateDetour(hGameData, "CTFPlayer::CanAirDash", _, DHook_CanAirDashPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::ValidateWeapons", DHook_ValidateWeaponsPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::DoClassSpecialSkill", DHook_DoClassSpecialSkillPre, DHook_DoClassSpecialSkillPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::GetChargeEffectBeingProvided", DHook_GetChargeEffectBeingProvidedPre, DHook_GetChargeEffectBeingProvidedPost);

--- a/scripting/randomizer/patch.sp
+++ b/scripting/randomizer/patch.sp
@@ -1,155 +1,85 @@
-static StringMap g_Patches;
+#define PATCH_MAX	16
 
-static void ApplyPatches(GameData hGameData)
+enum struct Patch
 {
-	StringMapSnapshot Snapshot = g_Patches.Snapshot();
-	int iLen = Snapshot.Length;
-	for (int i = 0; i < iLen; i++)
+	Address pAddress;
+	int iPatchCount;
+	int iValueOriginal[PATCH_MAX];
+	int iValueReplacement[PATCH_MAX];
+	bool bEnable;
+	
+	void Load(GameData hGameData, const char[] sPatchName)
 	{
-		char sKey[256];
-		Snapshot.GetKey(i, sKey, sizeof(sKey));
-		
-		any address = hGameData.GetAddress(sKey);
-		if (address)
+		this.pAddress = hGameData.GetAddress(sPatchName);
+		if (!this.pAddress)
 		{
-			ArrayList Patch;
-			if (g_Patches.GetValue(sKey, Patch))
-			{
-				int iPatchLen = Patch.Length;
-				for (int j = 0; j < iPatchLen; j++)
-				{
-					int iArray[3];
-					Patch.GetArray(j, iArray);
-					
-					int iVal = LoadFromAddress(address+iArray[0], NumberType_Int8);
-					if (iVal == iArray[1])
-					{
-						StoreToAddress(address+iArray[0], iArray[2], NumberType_Int8);
-					}
-					else
-					{
-						// Don't continue if our initial value doesn't match up
-						Patch_Reset(sKey, hGameData);
-						LogError("Patch %s failed: %X (at %X) != %X", sKey, iVal, address, iArray[1]);
-						break;
-					}
-				}
-			}
+			LogError("Failed to find address for key %s", sPatchName);
+			return;
+		}
+		
+		char sKeyValue[PATCH_MAX * 4];
+		if (!hGameData.GetKeyValue(sPatchName, sKeyValue, sizeof(sKeyValue)))
+		{
+			LogError("Failed to find key value for %s", sPatchName);
+			return;
+		}
+		
+		char sBytes[PATCH_MAX][4];
+		this.iPatchCount = ExplodeString(sKeyValue, "\\x", sBytes, sizeof(sBytes), sizeof(sBytes[])) - 1;
+		for (int i = 0; i < this.iPatchCount; i++)
+		{
+			this.iValueOriginal[i] = LoadFromAddress(this.pAddress + view_as<Address>(i), NumberType_Int8);
+			this.iValueReplacement[i] = StringToInt(sBytes[i+1], 16);
 		}
 	}
 	
-	delete Snapshot;
+	void Enable()
+	{
+		if (this.bEnable)
+			return;
+		
+		for (int i = 0; i < this.iPatchCount; i++)
+		{
+			PrintToServer("%X: %02X -> %02X", this.pAddress + view_as<Address>(i), this.iValueOriginal[i], this.iValueReplacement[i]);
+			StoreToAddress(this.pAddress + view_as<Address>(i), this.iValueReplacement[i], NumberType_Int8);
+		}
+		
+		this.bEnable = true;
+	}
+	
+	void Disable()
+	{
+		if (!this.bEnable)
+			return;
+		
+		for (int i = 0; i < this.iPatchCount; i++)
+		{
+			PrintToServer("%X: %02X -> %02X", this.pAddress + view_as<Address>(i), this.iValueReplacement[i], this.iValueOriginal[i]);
+			StoreToAddress(this.pAddress + view_as<Address>(i), this.iValueOriginal[i], NumberType_Int8);
+		}
+		
+		this.bEnable = false;
+	}
 }
+
+Patch g_patchHeavyClassCheck;
+Patch g_patchSteakCondFailed;
+Patch g_patchSteakCondPassed;
 
 void Patch_Init(GameData hGameData)
 {
-	bool bLinux = hGameData.GetOffset("DoWeHaveABetterWayOfGettingOS") != -1;
+	g_patchHeavyClassCheck.Load(hGameData, "Patch_HeavyClassCheck");
+	g_patchSteakCondFailed.Load(hGameData, "Patch_SteakCondFailed");
+	g_patchSteakCondPassed.Load(hGameData, "Patch_SteakCondPassed");
 	
-	g_Patches = new StringMap();
-	ArrayList Patch = new ArrayList(3); // In array: 0 index is offset, 1 - inital value, 2 - replacement
-	
-	if (bLinux)
-	{
-		//Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-		Patch.PushArray({0, 0x0F, 0x90});
-		Patch.PushArray({1, 0x84, 0xE9});
-		
-		g_Patches.SetValue("Patch_HeavyClassCheck", Patch.Clone());
-		Patch.Clear();
-		
-		//Replace 'jmp' at steak cond failed to BFB weapon check
-		Patch.PushArray({0, 0x0F, 0x0F});
-		Patch.PushArray({1, 0x84, 0x84});
-		Patch.PushArray({2, 0x25, 0xC2});
-		Patch.PushArray({3, 0xFB, 0x00});
-		Patch.PushArray({4, 0xFF, 0x00});
-		Patch.PushArray({5, 0xFF, 0x00});
-		
-		g_Patches.SetValue("Patch_SteakCondFailed", Patch.Clone());
-		Patch.Clear();
-		
-		//Replace 'jmp' at steak speed applied to BFB weapon check
-		Patch.PushArray({0, 0xE9, 0xE9});
-		Patch.PushArray({1, 0xFA, 0x97});
-		Patch.PushArray({2, 0xFA, 0x00});
-		Patch.PushArray({3, 0xFF, 0x00});
-		Patch.PushArray({4, 0xFF, 0x00});
-		
-		g_Patches.SetValue("Patch_SteakCondPassed", Patch.Clone());
-		Patch.Clear();
-	}
-	else
-	{
-		// Replace jnz short loc_104C0E8C with NOP because we don't need it if
-		// we want to check for bfb speed bonus after the condition check
-		Patch.PushArray({0, 0x75, 0x90});
-		Patch.PushArray({1, 0x4E, 0x90});
-		
-		g_Patches.SetValue("Patch_HeavyClassCheck", Patch.Clone());
-		Patch.Clear();
-		
-		// Replace jz loc_104C0EE2 to jz 0x2B so that we jump to the bfb
-		// check if player has no steak/crit-a-cola condition
-		Patch.PushArray({2, 0x81, 0x30}); // 0x104C0E5D
-		
-		g_Patches.SetValue("Patch_SteakCondFailed", Patch.Clone());
-		Patch.Clear();
-		
-		// Replace 'jbe' to 'jmp short' and always go to BFB
-		Patch.PushArray({0, 0x76, 0xEB}); // 0x104C0E81
-		Patch.PushArray({1, 0x60, 0x0F}); // 0x104C0E81
-		
-		g_Patches.SetValue("Patch_SteakCondPassed", Patch.Clone());
-		Patch.Clear();
-	}
-	
-	delete Patch;
-	
-	ApplyPatches(hGameData);
-}
-
-void Patch_Reset(char[] sName, GameData hGameData = null)
-{
-	if (!hGameData)
-	{
-		hGameData = new GameData("randomizer");
-		if (!hGameData)
-			SetFailState("Could not find randomizer gamedata");
-	}
-	
-	any address = hGameData.GetAddress(sName);
-	if (address)
-	{
-		ArrayList Patch;
-		if (g_Patches.GetValue(sName, Patch))
-		{
-			int iPatchLen = Patch.Length;
-			for (int j = 0; j < iPatchLen; j++)
-			{
-				int iArray[3];
-				Patch.GetArray(j, iArray);
-				
-				int iVal = LoadFromAddress(address+iArray[0], NumberType_Int8);
-				if (iVal == iArray[1] || iVal == iArray[2])
-					StoreToAddress(address+iArray[0], iArray[1], NumberType_Int8);
-				else
-					return;
-			}
-		}
-	}
+	g_patchHeavyClassCheck.Enable();
+	g_patchSteakCondFailed.Enable();
+	g_patchSteakCondPassed.Enable();
 }
 
 void Patch_ResetAll()
 {
-	StringMapSnapshot Snapshot = g_Patches.Snapshot();
-	int iLen = Snapshot.Length;
-	for (int i = 0; i < iLen; i++)
-	{
-		char sKey[256];
-		Snapshot.GetKey(i, sKey, sizeof(sKey));
-		
-		Patch_Reset(sKey);
-	}
-	
-	delete Snapshot;
+	g_patchHeavyClassCheck.Disable();
+	g_patchSteakCondFailed.Disable();
+	g_patchSteakCondPassed.Disable();
 }

--- a/scripting/randomizer/patch.sp
+++ b/scripting/randomizer/patch.sp
@@ -1,0 +1,133 @@
+static StringMap g_Patches;
+
+static void ApplyPatches(GameData hGameData)
+{
+	StringMapSnapshot Snapshot = g_Patches.Snapshot();
+	int iLen = Snapshot.Length;
+	for (int i = 0; i < iLen; i++)
+	{
+		char sKey[256];
+		Snapshot.GetKey(i, sKey, sizeof(sKey));
+		
+		any address = hGameData.GetAddress(sKey);
+		if (address)
+		{
+			ArrayList Patch;
+			if (g_Patches.GetValue(sKey, Patch))
+			{
+				int iPatchLen = Patch.Length;
+				for (int j = 0; j < iPatchLen; j++)
+				{
+					int iArray[3];
+					Patch.GetArray(j, iArray);
+					
+					int iVal = LoadFromAddress(address+iArray[0], NumberType_Int8);
+					if (iVal == iArray[1])
+					{
+						StoreToAddress(address+iArray[0], iArray[2], NumberType_Int8);
+					}
+					else
+					{
+						// Don't continue if our initial value doesn't match up
+						Patch_Reset(sKey, hGameData);
+						LogError("Patch %s failed: %X (at %X) != %X", sKey, iVal, address, iArray[1]);
+						break;
+					}
+				}
+			}
+		}
+	}
+	
+	delete Snapshot;
+}
+
+void Patch_Init(GameData hGameData)
+{
+	bool bLinux = hGameData.GetOffset("DoWeHaveABetterWayOfGettingOS") != -1;
+	
+	g_Patches = new StringMap();
+	ArrayList Patch = new ArrayList(3); // In array: 0 index is offset, 1 - inital value, 2 - replacement
+	
+	if (bLinux)
+	{
+		// Nothing here
+	}
+	else
+	{
+		// Replace jnz short loc_104C0E8C with NOP because we don't need it if
+		// we want to check for bfb speed bonus after the condition check
+		Patch.PushArray({-83, 0x75, 0x90}); // 0x104C0E3C
+		Patch.PushArray({-82, 0x4E, 0x90}); // 0x104C0E3D
+		
+		// Replace jz loc_104C0EE2 to jz 0x2B so that we jump to the bfb
+		// check if player has no steak/crit-a-cola condition
+		Patch.PushArray({-50, 0x81, 0x2B}); // 0x104C0E5D
+		
+		// Same as above
+		Patch.PushArray({-14, 0x60, 0xA}); // 0x104C0E81
+		
+		// Replace a jump with NOP for a bfb check
+		Patch.PushArray({-5, 0xEB, 0x90}); // 0x104C0E8A
+		Patch.PushArray({-4, 0x51, 0x90}); // 0x104C0E8B
+		
+		// Basically replace bunch of jumps that are related
+		// to the scout class check with NOP
+		Patch.PushArray({0,  0x75, 0x90}); // 0x104C0E8F
+		Patch.PushArray({1,  0x51, 0x90}); // 0x104C0E90
+		Patch.PushArray({13, 0x74, 0x90}); // 0x104C0E9C
+		Patch.PushArray({14, 0x44, 0x90}); // 0x104C0E9D
+		
+		g_Patches.SetValue("CTFPlayer::TeamFortress_CalculateMaxSpeed::BFBCheck", Patch.Clone());
+		Patch.Clear();
+	}
+	
+	delete Patch;
+	
+	ApplyPatches(hGameData);
+}
+
+void Patch_Reset(char[] sName, GameData hGameData = null)
+{
+	if (!hGameData)
+	{
+		hGameData = new GameData("randomizer");
+		if (!hGameData)
+			SetFailState("Could not find randomizer gamedata");
+	}
+	
+	any address = hGameData.GetAddress(sName);
+	if (address)
+	{
+		ArrayList Patch;
+		if (g_Patches.GetValue(sName, Patch))
+		{
+			int iPatchLen = Patch.Length;
+			for (int j = 0; j < iPatchLen; j++)
+			{
+				int iArray[3];
+				Patch.GetArray(j, iArray);
+				
+				int iVal = LoadFromAddress(address+iArray[0], NumberType_Int8);
+				if (iVal == iArray[1] || iVal == iArray[2])
+					StoreToAddress(address+iArray[0], iArray[1], NumberType_Int8);
+				else
+					return;
+			}
+		}
+	}
+}
+
+void Patch_ResetAll()
+{
+	StringMapSnapshot Snapshot = g_Patches.Snapshot();
+	int iLen = Snapshot.Length;
+	for (int i = 0; i < iLen; i++)
+	{
+		char sKey[256];
+		Snapshot.GetKey(i, sKey, sizeof(sKey));
+		
+		Patch_Reset(sKey);
+	}
+	
+	delete Snapshot;
+}

--- a/scripting/randomizer/patch.sp
+++ b/scripting/randomizer/patch.sp
@@ -50,34 +50,56 @@ void Patch_Init(GameData hGameData)
 	
 	if (bLinux)
 	{
-		// Nothing here
+		//Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+		Patch.PushArray({0, 0x0F, 0x90});
+		Patch.PushArray({1, 0x84, 0xE9});
+		
+		g_Patches.SetValue("Patch_HeavyClassCheck", Patch.Clone());
+		Patch.Clear();
+		
+		//Replace 'jmp' at steak cond failed to BFB weapon check
+		Patch.PushArray({0, 0x0F, 0x0F});
+		Patch.PushArray({1, 0x84, 0x84});
+		Patch.PushArray({2, 0x25, 0xC2});
+		Patch.PushArray({3, 0xFB, 0x00});
+		Patch.PushArray({4, 0xFF, 0x00});
+		Patch.PushArray({5, 0xFF, 0x00});
+		
+		g_Patches.SetValue("Patch_SteakCondFailed", Patch.Clone());
+		Patch.Clear();
+		
+		//Replace 'jmp' at steak speed applied to BFB weapon check
+		Patch.PushArray({0, 0xE9, 0xE9});
+		Patch.PushArray({1, 0xFA, 0x97});
+		Patch.PushArray({2, 0xFA, 0x00});
+		Patch.PushArray({3, 0xFF, 0x00});
+		Patch.PushArray({4, 0xFF, 0x00});
+		
+		g_Patches.SetValue("Patch_SteakCondPassed", Patch.Clone());
+		Patch.Clear();
 	}
 	else
 	{
 		// Replace jnz short loc_104C0E8C with NOP because we don't need it if
 		// we want to check for bfb speed bonus after the condition check
-		Patch.PushArray({-83, 0x75, 0x90}); // 0x104C0E3C
-		Patch.PushArray({-82, 0x4E, 0x90}); // 0x104C0E3D
+		Patch.PushArray({0, 0x75, 0x90});
+		Patch.PushArray({1, 0x4E, 0x90});
+		
+		g_Patches.SetValue("Patch_HeavyClassCheck", Patch.Clone());
+		Patch.Clear();
 		
 		// Replace jz loc_104C0EE2 to jz 0x2B so that we jump to the bfb
 		// check if player has no steak/crit-a-cola condition
-		Patch.PushArray({-50, 0x81, 0x2B}); // 0x104C0E5D
+		Patch.PushArray({2, 0x81, 0x30}); // 0x104C0E5D
 		
-		// Same as above
-		Patch.PushArray({-14, 0x60, 0xA}); // 0x104C0E81
+		g_Patches.SetValue("Patch_SteakCondFailed", Patch.Clone());
+		Patch.Clear();
 		
-		// Replace a jump with NOP for a bfb check
-		Patch.PushArray({-5, 0xEB, 0x90}); // 0x104C0E8A
-		Patch.PushArray({-4, 0x51, 0x90}); // 0x104C0E8B
+		// Replace 'jbe' to 'jmp short' and always go to BFB
+		Patch.PushArray({0, 0x76, 0xEB}); // 0x104C0E81
+		Patch.PushArray({1, 0x60, 0x0F}); // 0x104C0E81
 		
-		// Basically replace bunch of jumps that are related
-		// to the scout class check with NOP
-		Patch.PushArray({0,  0x75, 0x90}); // 0x104C0E8F
-		Patch.PushArray({1,  0x51, 0x90}); // 0x104C0E90
-		Patch.PushArray({13, 0x74, 0x90}); // 0x104C0E9C
-		Patch.PushArray({14, 0x44, 0x90}); // 0x104C0E9D
-		
-		g_Patches.SetValue("CTFPlayer::TeamFortress_CalculateMaxSpeed::BFBCheck", Patch.Clone());
+		g_Patches.SetValue("Patch_SteakCondPassed", Patch.Clone());
 		Patch.Clear();
 	}
 	

--- a/scripting/randomizer/patch.sp
+++ b/scripting/randomizer/patch.sp
@@ -62,24 +62,36 @@ enum struct Patch
 	}
 }
 
-Patch g_patchHeavyClassCheck;
-Patch g_patchSteakCondFailed;
-Patch g_patchSteakCondPassed;
+static Patch g_patchSpeedDemomanClassCheck;
+static Patch g_patchSpeedMedic1ClassCheck;
+static Patch g_patchSpeedMedic2ClassCheck;
+static Patch g_patchSpeedHeavyClassCheck;
+static Patch g_patchSpeedSteakCondFailed;
+static Patch g_patchSpeedSteakCondPassed;
 
 void Patch_Init(GameData hGameData)
 {
-	g_patchHeavyClassCheck.Load(hGameData, "Patch_HeavyClassCheck");
-	g_patchSteakCondFailed.Load(hGameData, "Patch_SteakCondFailed");
-	g_patchSteakCondPassed.Load(hGameData, "Patch_SteakCondPassed");
+	g_patchSpeedDemomanClassCheck.Load(hGameData, "Patch_SpeedDemomanClassCheck");
+	g_patchSpeedMedic1ClassCheck.Load(hGameData, "Patch_SpeedMedic1ClassCheck");
+	g_patchSpeedMedic2ClassCheck.Load(hGameData, "Patch_SpeedMedic2ClassCheck");
+	g_patchSpeedHeavyClassCheck.Load(hGameData, "Patch_SpeedHeavyClassCheck");
+	g_patchSpeedSteakCondFailed.Load(hGameData, "Patch_SpeedSteakCondFailed");
+	g_patchSpeedSteakCondPassed.Load(hGameData, "Patch_SpeedSteakCondPassed");
 	
-	g_patchHeavyClassCheck.Enable();
-	g_patchSteakCondFailed.Enable();
-	g_patchSteakCondPassed.Enable();
+	g_patchSpeedDemomanClassCheck.Enable();
+	g_patchSpeedMedic1ClassCheck.Enable();
+	g_patchSpeedMedic2ClassCheck.Enable();
+	g_patchSpeedHeavyClassCheck.Enable();
+	g_patchSpeedSteakCondFailed.Enable();
+	g_patchSpeedSteakCondPassed.Enable();
 }
 
 void Patch_ResetAll()
 {
-	g_patchHeavyClassCheck.Disable();
-	g_patchSteakCondFailed.Disable();
-	g_patchSteakCondPassed.Disable();
+	g_patchSpeedDemomanClassCheck.Disable();
+	g_patchSpeedMedic1ClassCheck.Disable();
+	g_patchSpeedMedic2ClassCheck.Disable();
+	g_patchSpeedHeavyClassCheck.Disable();
+	g_patchSpeedSteakCondFailed.Disable();
+	g_patchSpeedSteakCondPassed.Disable();
 }


### PR DESCRIPTION
This took me and Haxton Sale 3 days and brain damages to figure out how to fix this, but it finally done.

`CTFPlayer::TeamFortress_CalculateMaxSpeed` have a lot of class checks all crammed into 1 function, so a simple class change during hook won't do the trick. Instead a memory patch is used, which allows to change function instructions in assembly.

A lot of patches is either `jmp` (always jump) or `nop` (skip) on several class checks so it would always pass for all classes. However there is an extra problem with Buffalo Steak Sandvich and Baby Face Blaster (pseudocode):
```
if (class == TF_CLASS_HEAVY)
{
	// Buffalo Steak Sandvich code
}
else if (class == TF_CLASS_SCOUT)
{
	// Baby Face Blaster code
}
```
There an `else if` for this, meaning both can't normally be run at once. So in memory patch after finishing steak, it then jumped to bfb instead of skipping it (also skipping scout class check).

And there one last problem, `TF_COND_ENERGY_BUFF` is used on Crit-a-Cola, Buffalo Steak Sandvich and Cleaners Carbine. While we only want to give extra speed to steak, memory patch also gave other weapons speed. So `CTFPlayerShared::InCond` detour had to be made to fix this.