### PR TITLE
Add some new convars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ TF2 Gamemode where everyone plays as random class with random weapons, a rewritt
 
 ## ConVars
 - `randomizer_version`: Plugin version number, don't touch.
-- `randomizer_enabled`: Enable/Disable randomizer, another option for load/unload plugins
+- `randomizer_enabled`: Enable/Disable entire randomizer plugin, another option for load/unload plugins.
+- `randomizer_randomweapons`: Enable/Disable player class weapon randomization on spawn/death, disabling will still preform weapon fixes.
+- `randomizer_droppedweapons`: Enable/Disable dropped weapons.
+- `randomizer_huds`: Enable/Disable weapon huds.
 
 ## Commands
 - `sm_cantsee`: Set your active weapon transparent or fully visible, for everyone

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ TF2 Gamemode where everyone plays as random class with random weapons, a rewritt
 ## ConVars
 - `randomizer_version`: Plugin version number, don't touch.
 - `randomizer_enabled`: Enable/Disable entire randomizer plugin, another option for load/unload plugins.
-- `randomizer_randomweapons`: Enable/Disable player class weapon randomization on spawn/death, disabling will still preform weapon fixes.
+- `randomizer_randomclass`: Enable/Disable player class randomization, disabling will allow player to change any class.
+- `randomizer_randomweapons`: Enable/Disable player weapon randomization, disabling will allow player to keep its weapon while still preforming weapon fixes.
 - `randomizer_droppedweapons`: Enable/Disable dropped weapons.
 - `randomizer_huds`: Enable/Disable weapon huds.
 

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -525,6 +525,20 @@
 					}
 				}
 			}
+			"CBasePlayer::EquipWearable"
+			{
+				"offset"	"CBasePlayer::EquipWearable"
+				"hooktype"	"entity"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pItem"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
 			"CTFPlayer::GiveNamedItem"
 			{
 				"offset"	"CTFPlayer::GiveNamedItem"

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -252,6 +252,11 @@
 				"linux"		"376"
 				"windows"	"374"
 			}
+			"CBasePlayer::ForceRespawn"
+			{
+				"linux"		"330"
+				"windows"	"329"
+			}
 			"CBasePlayer::EquipWearable"
 			{
 				"linux"		"431"
@@ -524,6 +529,13 @@
 						"type"	"cbaseentity"
 					}
 				}
+			}
+			"CBasePlayer::ForceRespawn"
+			{
+				"offset"	"CBasePlayer::ForceRespawn"
+				"hooktype"	"entity"
+				"return"	"void"
+				"this"		"entity"
 			}
 			"CBasePlayer::EquipWearable"
 			{

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -421,6 +421,11 @@ void DisableRandomizer()
 
 public void GenerateRandomWeapon(int iClient)
 {
+	if (g_cvRandomClass.BoolValue)
+		g_iClientClass[iClient] = view_as<TFClassType>(GetRandomInt(CLASS_MIN, CLASS_MAX));
+	else
+		g_iClientClass[iClient] = TF2_GetPlayerClass(iClient);
+	
 	if (g_cvRandomWeapons.BoolValue)
 	{
 		//Detach client's object so it doesnt get destroyed on losing toolbox
@@ -439,17 +444,8 @@ public void GenerateRandomWeapon(int iClient)
 			g_iClientWeaponIndex[iClient][iSlot] = -1;
 	}
 	
-	if (g_cvRandomClass.BoolValue)
-	{
-		g_iClientClass[iClient] = view_as<TFClassType>(GetRandomInt(CLASS_MIN, CLASS_MAX));
-		
-		if (IsPlayerAlive(iClient))
-			TF2_RespawnPlayer(iClient);
-	}
-	else
-	{
-		g_iClientClass[iClient] = TF2_GetPlayerClass(iClient);
-	}
+	if (g_cvRandomClass.BoolValue && IsPlayerAlive(iClient))
+		TF2_RespawnPlayer(iClient);
 }
 
 public Action Event_RoundStart(Event event, const char[] sName, bool bDontBroadcast)

--- a/scripting/randomizer/huds.sp
+++ b/scripting/randomizer/huds.sp
@@ -220,6 +220,9 @@ void Huds_RefreshClient(int iClient)
 		g_hudWeapon[iClient][iSlot] = nothing;
 	}
 	
+	if (!g_cvHuds.BoolValue)	//ConVar dont want us to do anything
+		return;
+	
 	int iWeapon;
 	int iPos;
 	while (TF2_GetItem(iClient, iWeapon, iPos))
@@ -266,6 +269,9 @@ public Action Huds_ClientDisplay(Handle hTimer, int iClient)
 {
 	if (g_hTimerClientHud[iClient] != hTimer)
 		return Plugin_Stop;
+	
+	if (!g_cvHuds.BoolValue)	//ConVar dont want us to do anything
+		return Plugin_Continue;
 	
 	int iActiveWeapon = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
 	if (iActiveWeapon <= MaxClients)

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -2,12 +2,14 @@ void SDKHook_HookClient(int iClient)
 {
 	SDKHook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
+	SDKHook(iClient, SDKHook_WeaponEquipPost, Client_WeaponEquipPost);
 }
 
 void SDKHook_UnhookClient(int iClient)
 {
 	SDKUnhook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKUnhook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
+	SDKUnhook(iClient, SDKHook_WeaponEquipPost, Client_WeaponEquipPost);
 }
 
 void SDKHook_HookWeapon(int iWeapon)
@@ -81,6 +83,15 @@ public void Client_PreThink(int iClient)
 public void Client_PreThinkPost(int iClient)
 {
 	g_iAllowPlayerClass[iClient]--;
+}
+
+public void Client_WeaponEquipPost(int iClient, int iWeapon)
+{
+	PrintToServer("Client_WeaponEquipPost %N", iClient);
+	
+	//New weapon is given from somewhere, refresh controls and huds
+	Controls_RefreshClient(iClient);
+	Huds_RefreshClient(iClient);
 }
 
 public void Weapon_SpawnPost(int iWeapon)

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -87,8 +87,6 @@ public void Client_PreThinkPost(int iClient)
 
 public void Client_WeaponEquipPost(int iClient, int iWeapon)
 {
-	PrintToServer("Client_WeaponEquipPost %N", iClient);
-	
 	//New weapon is given from somewhere, refresh controls and huds
 	Controls_RefreshClient(iClient);
 	Huds_RefreshClient(iClient);

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -314,6 +314,9 @@ stock int TF2_SpawnParticle(const char[] sParticle, int iEntity)
 
 stock int CanKeepWeapon(int iClient, const char[] sClassname, int iIndex)
 {
+	if (!g_cvRandomWeapons.BoolValue)
+		return true;
+	
 	//Allow grappling hook and passtime gun
 	if (g_bAllowGiveNamedItem || StrEqual(sClassname, "tf_weapon_grapplinghook") || StrEqual(sClassname, "tf_weapon_passtime_gun"))
 		return true;


### PR DESCRIPTION
`randomizer_randomweapons`: Enable/Disable player class weapon randomization on spawn/death. Disabling would allow admin or subplugin to give any weapons to player while randomizer will still preform weapon fixes.
`randomizer_droppedweapons`: Enable/Disable dropped weapons.
`randomizer_huds`: Enable/Disable weapon huds.

Note that Huds ignore reskin weapons. Later plugin will support reskin weapons and allowing players to equip reskins from random pool when possible, but not in this PR.