### PR TITLE
Fix reload times and server crash on banner use

### DIFF
--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -663,6 +663,12 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 				LogError("Unable to create weapon! index (%d)", g_iClientWeaponIndex[iClient][iSlot]);
 			}
 			
+			//Change class before equipping the weapon, otherwise reload times are odd
+			//This also somehow fixes sniper with a banner
+			TFClassType nClass = TF2_GetDefaultClassFromItem(iClient, iWeapon);
+			if (nClass != TFClass_Unknown)
+				TF2_SetPlayerClass(iClient, nClass);
+			
 			//CTFPlayer::ItemsMatch doesnt like normal item quality, so lets use unique instead
 			if (view_as<TFQuality>(GetEntProp(iWeapon, Prop_Send, "m_iEntityQuality")) == TFQual_Normal)
 				SetEntProp(iWeapon, Prop_Send, "m_iEntityQuality", TFQual_Unique);
@@ -689,6 +695,7 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 			}
 		}
 	}
+	TF2_SetPlayerClass(iClient, g_iClientClass[iClient]);
 }
 
 public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroadcast)

--- a/scripting/randomizer/commands.sp
+++ b/scripting/randomizer/commands.sp
@@ -68,8 +68,12 @@ public Action Command_Class(int iClient, int iArgs)
 		}
 		case Mode_Normal, Mode_NormalRound:
 		{
-			for (int i = 0; i < iTargetCount; i++)
-				g_iClientClass[iClient] = nClass;
+			for (int i = 0; i < iTargetCount; i++) {
+				g_iClientClass[iTargetList[i]] = nClass;
+				//Regenerate each slot beyond 2, as we generally don't want other classes to have watches/PDAs
+				for (int iSlot = 3; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+					g_iClientWeaponIndex[iTargetList[i]][iSlot] = Weapons_GetRandomIndex(iSlot, g_iClientClass[iTargetList[i]]);
+			}
 		}
 		case Mode_Team:
 		{

--- a/scripting/randomizer/commands.sp
+++ b/scripting/randomizer/commands.sp
@@ -68,7 +68,8 @@ public Action Command_Class(int iClient, int iArgs)
 		}
 		case Mode_Normal, Mode_NormalRound:
 		{
-			for (int i = 0; i < iTargetCount; i++) {
+			for (int i = 0; i < iTargetCount; i++) 
+			{
 				g_iClientClass[iTargetList[i]] = nClass;
 				//Regenerate each slot beyond 2, as we generally don't want other classes to have watches/PDAs
 				for (int iSlot = 3; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
@@ -95,8 +96,24 @@ public Action Command_Class(int iClient, int iArgs)
 			}
 			
 			for (int iTeam = TEAM_MIN; iTeam <= TEAM_MAX; iTeam++)
+			{
 				if (bTargetTeam[iTeam])
+				{
 					g_iTeamClass[iTeam] = nClass;
+					//If doing normal random weapons, we need to regenerate pda slots for each player on the team
+					if (g_cvRandomWeapons.IntValue == Mode_Normal || g_cvRandomWeapons.IntValue == Mode_NormalRound)
+					{
+					 for (int iTarget = 1; iTarget <= MaxClients; iTarget++)
+					  if (IsClientInGame(iTarget) && bTargetTeam[TF2_GetClientTeam(iTarget)])
+					   for (int iSlot = 3; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+					    g_iClientWeaponIndex[iTarget][iSlot] = Weapons_GetRandomIndex(iSlot, g_iTeamClass[iTeam]);
+					}
+					else if (g_cvRandomWeapons.IntValue == Mode_Team || g_cvRandomWeapons.IntValue == Mode_All)
+				  for (int iSlot = 3; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+					  g_iTeamWeaponIndex[iTeam][iSlot] = Weapons_GetRandomIndex(iSlot, g_iTeamClass[iTeam]);
+					  
+		  }
+		 }
 		}
 		case Mode_All:
 		{
@@ -110,14 +127,27 @@ public Action Command_Class(int iClient, int iArgs)
 			}
 			
 			for (int iTeam = TEAM_MIN; iTeam <= TEAM_MAX; iTeam++)
+			{
 				g_iTeamClass[iTeam] = nClass;
+				if (g_cvRandomWeapons.IntValue == Mode_Normal || g_cvRandomWeapons.IntValue == Mode_NormalRound)
+				{
+				 for (int iTarget = 1; iTarget <= MaxClients; iTarget++)
+				  if (IsClientInGame(iTarget))
+				   for (int iSlot = 3; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+				    g_iClientWeaponIndex[iTarget][iSlot] = Weapons_GetRandomIndex(iSlot, g_iTeamClass[iTeam]);
+				}
+				else if (g_cvRandomWeapons.IntValue == Mode_Team || g_cvRandomWeapons.IntValue == Mode_All)
+				 for (int iSlot = 3; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+				  g_iTeamWeaponIndex[iTeam][iSlot] = Weapons_GetRandomIndex(iSlot, g_iTeamClass[iTeam]);
+					 
+		 }
 		}
 	}
 	
 	for (int i = 0; i < iTargetCount; i++)
 		if (IsPlayerAlive(iTargetList[i]))
 			TF2_RespawnPlayer(iTargetList[i]);
-	
+			
 	ReplyToCommand(iClient, "Set %s class to %s", sTargetName, sClass);
 	return Plugin_Handled;
 }


### PR DESCRIPTION
Before equipping weapons, change the player's class to the default class for that weapon. This fixes classes having different reload times with the same weapon (#22) and server crash when using banners as sniper ( #11)

sm_rndclass still seems to break reload times until the player respawns

Also, I screwed up when pulling commits, so this pull request has 3 do-nothing commits.