### PR TITLE
Fix reload speeds and banners not gaining rage

### DIFF
--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -739,8 +739,8 @@ void SetClientClass(int iClient, TFClassType nClass)
 	if (g_iClientCurrentClass[iClient] == TFClass_Unknown)
 	{
 		g_iClientCurrentClass[iClient] = TF2_GetPlayerClass(iClient);
-		TF2_SetPlayerClass(iClient, nClass);
 	}
+	TF2_SetPlayerClass(iClient, nClass);
 }
 
 void RevertClientClass(int iClient)


### PR DESCRIPTION
Force SetClientClass to always change the players class, even if called multiple times before RevertClientClass.
This caused issues when equipping players with loadouts and handling rage gain, as their class would be changed for the first slot, but remain the same for the remaining slots.