### PR TITLE
Fix crashes from sniper viewmodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To download latest build version, select latest package then "Artifacts" button 
 
 ## Requirements
 - SourceMod 1.10
+- [tf2attributes](https://forums.alliedmods.net/showthread.php?t=210221)
 - [tf_econ_data](https://forums.alliedmods.net/showthread.php?t=315011)
 - [dhooks with detour support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)
 

--- a/configs/randomizer/viewmodels.cfg
+++ b/configs/randomizer/viewmodels.cfg
@@ -27,6 +27,7 @@
 	"RobotArm"
 	{
 		"tf_weapon_raygun"			"sniper"
+		"tf_weapon_rocketpack"		"sniper"
 		"tf_weapon_fists"			"sniper"
 	}
 }

--- a/configs/randomizer/viewmodels.cfg
+++ b/configs/randomizer/viewmodels.cfg
@@ -23,4 +23,10 @@
 		"tf_weapon_medigun"			"demoman"
 		"tf_weapon_medigun"			"heavy"
 	}
+	
+	"RobotArm"
+	{
+		"tf_weapon_raygun"			"sniper"
+		"tf_weapon_fists"			"sniper"
+	}
 }

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -5,6 +5,7 @@
 #include <sdkhooks>
 #include <tf2>
 #include <tf2_stocks>
+#include <tf2attributes>
 #include <tf_econ_data>
 #include <dhooks>
 
@@ -14,7 +15,7 @@
 
 #pragma newdecls required
 
-#define PLUGIN_VERSION			"1.4.0"
+#define PLUGIN_VERSION			"1.5.0"
 #define PLUGIN_VERSION_REVISION	"manual"
 
 #define TF_MAXPLAYERS	34	//32 clients + 1 for 0/world/console + 1 for replay/SourceTV
@@ -661,12 +662,6 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 				LogError("Unable to create weapon! index (%d)", g_iClientWeaponIndex[iClient][iSlot]);
 			}
 			
-			//Change class before equipping the weapon, otherwise reload times are odd
-			//This also somehow fixes sniper with a banner
-			TFClassType nClass = TF2_GetDefaultClassFromItem(iWeapon);
-			if (nClass != TFClass_Unknown)
-				SetClientClass(iClient, nClass);
-			
 			//CTFPlayer::ItemsMatch doesnt like normal item quality, so lets use unique instead
 			if (view_as<TFQuality>(GetEntProp(iWeapon, Prop_Send, "m_iEntityQuality")) == TFQual_Normal)
 				SetEntProp(iWeapon, Prop_Send, "m_iEntityQuality", TFQual_Unique);
@@ -693,8 +688,6 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 			}
 		}
 	}
-	
-	RevertClientClass(iClient);
 }
 
 public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroadcast)

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -2,6 +2,7 @@ void SDKHook_HookClient(int iClient)
 {
 	SDKHook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
+	SDKHook(iClient, SDKHook_WeaponEquip, Client_WeaponEquip);
 	SDKHook(iClient, SDKHook_WeaponEquipPost, Client_WeaponEquipPost);
 }
 
@@ -9,6 +10,7 @@ void SDKHook_UnhookClient(int iClient)
 {
 	SDKUnhook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKUnhook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
+	SDKUnhook(iClient, SDKHook_WeaponEquip, Client_WeaponEquip);
 	SDKUnhook(iClient, SDKHook_WeaponEquipPost, Client_WeaponEquipPost);
 }
 
@@ -82,9 +84,22 @@ public void Client_PreThinkPost(int iClient)
 	g_iAllowPlayerClass[iClient]--;
 }
 
+public Action Client_WeaponEquip(int iClient, int iWeapon)
+{
+	//Change class before equipping the weapon, otherwise reload times are odd
+	//This also somehow fixes sniper with a banner
+	SetClientClass(iClient, TF2_GetDefaultClassFromItem(iWeapon));
+}
+
 public void Client_WeaponEquipPost(int iClient, int iWeapon)
 {
-	//New weapon is given from somewhere, refresh controls and huds
+	RevertClientClass(iClient);
+	
+	//Give robot arm viewmodel if weapon isnt good with current viewmodel
+	if (ViewModels_ShouldUseRobotArm(iClient, iWeapon))
+		TF2Attrib_SetByName(iWeapon, "mod wrench builds minisentry", 1.0);
+	
+	//Refresh controls and huds
 	Controls_RefreshClient(iClient);
 	Huds_RefreshClient(iClient);
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,5 +11,6 @@ cp -r ../scripting addons/sourcemod
 cd addons/sourcemod/scripting
 
 # Install Dependencies
+wget "https://raw.githubusercontent.com/FlaminSarge/tf2attributes/master/tf2attributes.inc" -O include/tf2attributes.inc
 wget "https://raw.githubusercontent.com/nosoop/SM-TFEconData/master/scripting/include/tf_econ_data.inc" -O include/tf_econ_data.inc
 wget "https://raw.githubusercontent.com/peace-maker/DHooks2/dynhooks/sourcemod/scripting/include/dhooks.inc" -O include/dhooks.inc


### PR DESCRIPTION
Fixes #37 

This bumps plugin version to 1.5.0 due to tf2attributes now required to run this plugin (we might be able to reuse tf2attribs for other fixes if there any).

Sniper's hand viewmodel is not very nice when used with specific weapons, leading to a crash. I'm not sure if there a direct way to fix this whenever if its entirely loaded serverside or clientside also loads it. But since Randomizer Arena uses robot arm workaround, may well then uses it.

Giving attribute `mod wrench builds minisentry` to weapon enables robot arm viewmodel, note that this isn't enough to enable build minisentry (thanks valve). Can be configured at `viewmodels.cfg` on which weapons and class combo should give robot arm viewmodel.

@Djrulz0826 @doomy64 Do you know any other weapons that can crash from sniper viewmodel?