### PR TITLE
Fix Eureka Effect teleport (#48)

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -278,6 +278,11 @@
 				"linux"		"484"
 				"windows"	"477"
 			}
+			"CTFPlayer::ClientCommand"
+			{
+			 "linux"  "373"
+			 "windows" "372"
+			}
 			"CGameRules::FrameUpdatePostEntityThink"
 			{
 				"linux"		"16"
@@ -642,6 +647,20 @@
 					"b"
 					{
 						"type"	"bool"
+					}
+				}
+			}
+			"CTFPlayer::ClientCommand"
+			{
+				"offset"	"CTFPlayer::ClientCommand"
+				"hooktype"	"entity"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"pArgs"
+					{
+						"type"	"objectptr"
 					}
 				}
 			}

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -241,6 +241,8 @@ int g_iAllowPlayerClass[TF_MAXPLAYERS];
 int g_iMedigunBeamRef[TF_MAXPLAYERS] = {INVALID_ENT_REFERENCE, ...};
 Handle g_hTimerClientHud[TF_MAXPLAYERS];
 
+int g_iClientEurekaTeleporting;
+
 #include "randomizer/controls.sp"
 #include "randomizer/huds.sp"
 #include "randomizer/viewmodels.sp"
@@ -291,6 +293,8 @@ public void OnPluginStart()
 	HookEvent("teamplay_round_start", Event_RoundStart, EventHookMode_Pre);
 	HookEvent("post_inventory_application", Event_PlayerInventoryUpdate);
 	HookEvent("player_death", Event_PlayerDeath, EventHookMode_Pre);
+	
+	AddCommandListener(Event_EurekaTeleport, "eureka_teleport");
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
@@ -725,6 +729,13 @@ KeyValues LoadConfig(const char[] sFilepath, const char[] sName)
 	}
 	
 	return kv;
+}
+
+public Action Event_EurekaTeleport(int iClient, const char[] sCommand, int iArgs)
+{
+ //We may not always be able to decrement g_iClientClass, so we'll just use a variable that gets cleared when calling IsPlayerClass
+	g_iClientEurekaTeleporting = iClient;
+	return Plugin_Continue;
 }
 
 void SetClientClass(int iClient, TFClassType nClass)

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -416,12 +416,6 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 		RemoveEntity(iEntity);
 }
 
-public void OnGameFrame()
-{
-	//There isn't another event we can reset this reliably (this is also why we're not using g_iAllowClientClass)
-	g_iClientEurekaTeleporting = 0;
-}
-
 public void ConVar_EnableChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	if (!!StringToInt(newValue))

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -416,6 +416,12 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 		RemoveEntity(iEntity);
 }
 
+public void OnGameFrame()
+{
+	//There isn't another event we can reset this reliably (this is also why we're not using g_iAllowClientClass)
+	g_iClientEurekaTeleporting = 0;
+}
+
 public void ConVar_EnableChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	if (!!StringToInt(newValue))
@@ -708,6 +714,13 @@ public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroad
 		UpdateClientWeapon(iClient, ClientUpdate_Death);
 }
 
+public Action Event_EurekaTeleport(int iClient, const char[] sCommand, int iArgs)
+{
+	g_iClientEurekaTeleporting = iClient;
+	return Plugin_Continue;
+}
+
+
 KeyValues LoadConfig(const char[] sFilepath, const char[] sName)
 {
 	char sConfigPath[PLATFORM_MAX_PATH];
@@ -729,13 +742,6 @@ KeyValues LoadConfig(const char[] sFilepath, const char[] sName)
 	}
 	
 	return kv;
-}
-
-public Action Event_EurekaTeleport(int iClient, const char[] sCommand, int iArgs)
-{
- //We may not always be able to decrement g_iClientClass, so we'll just use a variable that gets cleared when calling IsPlayerClass
-	g_iClientEurekaTeleporting = iClient;
-	return Plugin_Continue;
 }
 
 void SetClientClass(int iClient, TFClassType nClass)

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -18,6 +18,7 @@ static Handle g_hDHookCanBeUpgraded;
 static Handle g_hDHookForceRespawn;
 static Handle g_hDHookEquipWearable;
 static Handle g_hDHookGiveNamedItem;
+static Handle g_hDHookClientCommand;
 static Handle g_hDHookFrameUpdatePostEntityThink;
 
 static bool g_bSkipHandleRageGain;
@@ -25,6 +26,7 @@ static int g_iClientGetChargeEffectBeingProvided;
 static int g_iWeaponGetLoadoutItem = -1;
 
 static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS+1];
+static int g_iHookIdClientCommand[TF_MAXPLAYERS+1];
 static int g_iHookIdGiveAmmo[TF_MAXPLAYERS+1];
 static int g_iHookIdForceRespawnPre[TF_MAXPLAYERS+1];
 static int g_iHookIdForceRespawnPost[TF_MAXPLAYERS+1];
@@ -63,6 +65,7 @@ public void DHook_Init(GameData hGameData)
 	g_hDHookForceRespawn = DHook_CreateVirtual(hGameData, "CBasePlayer::ForceRespawn");
 	g_hDHookEquipWearable = DHook_CreateVirtual(hGameData, "CBasePlayer::EquipWearable");
 	g_hDHookGiveNamedItem = DHook_CreateVirtual(hGameData, "CTFPlayer::GiveNamedItem");
+	g_hDHookClientCommand = DHook_CreateVirtual(hGameData, "CTFPlayer::ClientCommand");
 	g_hDHookFrameUpdatePostEntityThink = DHook_CreateVirtual(hGameData, "CGameRules::FrameUpdatePostEntityThink");
 }
 
@@ -158,6 +161,7 @@ void DHook_HookClient(int iClient)
 	g_iHookIdForceRespawnPre[iClient] = DHookEntity(g_hDHookForceRespawn, false, iClient, _, DHook_ForceRespawnPre);
 	g_iHookIdForceRespawnPost[iClient] = DHookEntity(g_hDHookForceRespawn, true, iClient, _, DHook_ForceRespawnPost);
 	g_iHookIdEquipWearable[iClient] = DHookEntity(g_hDHookEquipWearable, true, iClient, _, DHook_EquipWearablePost);
+	g_iHookIdClientCommand[iClient] = DHookEntity(g_hDHookClientCommand, true, iClient, _, DHook_ClientCommandPost);
 }
 
 void DHook_UnhookClient(int iClient)
@@ -185,6 +189,11 @@ void DHook_UnhookClient(int iClient)
 		DHookRemoveHookID(g_iHookIdEquipWearable[iClient]);
 		g_iHookIdEquipWearable[iClient] = 0;	
 	}
+	if (g_iHookIdClientCommand[iClient])
+	{
+		DHookRemoveHookID(g_iHookIdClientCommand[iClient]);
+		g_iHookIdClientCommand[iClient] = 0;
+ }
 }
 
 void DHook_OnEntityCreated(int iEntity, const char[] sClassname)
@@ -717,6 +726,12 @@ public void DHook_GiveNamedItemRemoved(int iHookId)
 			return;
 		}
 	}
+}
+
+public MRESReturn DHook_ClientCommandPost(int iClient, Handle hReturn, Handle hParams)
+{
+	if(iClient == g_iClientEurekaTeleporting)
+	 g_iClientEurekaTeleporting = 0;
 }
 
 public MRESReturn DHook_FrameUpdatePostEntityThinkPre()

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -403,6 +403,13 @@ public MRESReturn DHook_IsPlayerClassPre(int iClient, Handle hReturn, Handle hPa
 		return MRES_Supercede;
 	}
 	
+	if (g_iClientEurekaTeleporting == iClient) 
+	{
+		g_iClientEurekaTeleporting = 0;
+		DHookSetReturn(hReturn, true);
+		return MRES_Supercede;
+ }
+	
 	return MRES_Ignored;
 }
 

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -405,7 +405,6 @@ public MRESReturn DHook_IsPlayerClassPre(int iClient, Handle hReturn, Handle hPa
 	
 	if (g_iClientEurekaTeleporting == iClient) 
 	{
-		g_iClientEurekaTeleporting = 0;
 		DHookSetReturn(hReturn, true);
 		return MRES_Supercede;
  }


### PR DESCRIPTION
Fixes #48 
Add a listener for the player command "eureka_teleport".
Have `IsPlayerClass` always return true when using this command.
There isn't another event that fires _every_ time this command is called, which is why we don't use `g_iAllowClientClass` and why we reset the new variable the frame after running.