### PR TITLE
Fix Your Eternal Reward disguising

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -208,6 +208,12 @@
 				"linux"		"@_ZN20CTFPlayerClassShared14CanBuildObjectEi"
 				"windows"	"\x55\x8B\xEC\x53\x56\xFF\x71\x04"
 			}
+			"CTFKnife::DisguiseOnKill"
+			{
+			 "library" "server"
+			 "linux"  "_ZN8CTFKnife14DisguiseOnKillEv"
+			 "windows" "\x55\x8B\xEC\x51\x56\x8B\xF1\x8B\x96\x00\x08\x00\x00"
+			}
 			"CTFGameStats::Event_PlayerFiredWeapon"
 			{
 				"library"	"server"
@@ -459,6 +465,13 @@
 						"type"	"int"
 					}
 				}
+			}
+			"CTFKnife::DisguiseOnKill"
+			{
+			 "signature" "CTFKnife::DisguiseOnKill"
+			 "callconv" "thiscall"
+			 "return" "void"
+			 "this" "entity"
 			}
 			"CTFGameStats::Event_PlayerFiredWeapon"
 			{

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -211,7 +211,7 @@
 			"CTFKnife::DisguiseOnKill"
 			{
 			 "library" "server"
-			 "linux"  "_ZN8CTFKnife14DisguiseOnKillEv"
+			 "linux"  "@_ZN8CTFKnife14DisguiseOnKillEv"
 			 "windows" "\x55\x8B\xEC\x51\x56\x8B\xF1\x8B\x96\x00\x08\x00\x00"
 			}
 			"CTFGameStats::Event_PlayerFiredWeapon"

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -52,6 +52,7 @@ public void DHook_Init(GameData hGameData)
 	DHook_CreateDetour(hGameData, "CTFPlayer::GetLoadoutItem", DHook_GetLoadoutItemPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::GetEntityForLoadoutSlot", DHook_GetEntityForLoadoutSlotPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayerClassShared::CanBuildObject", DHook_CanBuildObjectPre, _);
+	DHook_CreateDetour(hGameData, "CTFKnife::DisguiseOnKill", DHook_DisguiseOnKillPre, DHook_DisguiseOnKillPost);
 	DHook_CreateDetour(hGameData, "CTFGameStats::Event_PlayerFiredWeapon", DHook_PlayerFiredWeaponPre, _);
 	DHook_CreateDetour(hGameData, "HandleRageGain", DHook_HandleRageGainPre, _);
 	
@@ -488,6 +489,18 @@ public MRESReturn DHook_CanBuildObjectPre(Address pPlayerClassShared, Handle hRe
 	//Always return true no matter what
 	DHookSetReturn(hReturn, true);
 	return MRES_Supercede;
+}
+
+public MRESReturn DHook_DisguiseOnKillPre(int iWeapon)
+{
+	int iClient = GetEntPropEnt(iWeapon, Prop_Send, "m_hOwnerEntity");
+	SetClientClass(iClient, TFClass_Spy);
+}
+
+public MRESReturn DHook_DisguiseOnKillPost(int iWeapon)
+{
+	int iClient = GetEntPropEnt(iWeapon, Prop_Send, "m_hOwnerEntity");
+	RevertClientClass(iClient);
 }
 
 public MRESReturn DHook_PlayerFiredWeaponPre(Address pGameStats, Handle hParams)


### PR DESCRIPTION
Fixes #45 
Only notable issue is being disguised when not a spy makes you appear to be a red player to your teammates, even on blu
Nameplates still work fine, and even say "Disguised as [class]".
Any ideas on how to fix this (if its even possible) would be appreciated.