### PR TITLE
Prevent Dalokohs Bar from overhealing

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -205,7 +205,7 @@
 			"CTFPlayer::TakeHealth"
 			{
 				"library" "server"
-				"linux" 	"_ZN9CTFPlayer10TakeHealthEfi"
+				"linux" 	"@_ZN9CTFPlayer10TakeHealthEfi"
 				"windows" "\x55\x8B\xEC\x56\x8B\xF1\x6A\x1F"
 			}
 			"CTFPlayerClassShared::CanBuildObject"

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -202,6 +202,12 @@
 				"linux"		"@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x83\x3D\x2A\x2A\x2A\x2A\x00"
 			}
+			"CTFPlayer::TakeHealth"
+			{
+				"library" "server"
+				"linux" 	"_ZN9CTFPlayer10TakeHealthEfi"
+				"windows" "\x55\x8B\xEC\x56\x8B\xF1\x6A\x1F"
+			}
 			"CTFPlayerClassShared::CanBuildObject"
 			{
 				"library"	"server"
@@ -213,6 +219,12 @@
 			 "library" "server"
 			 "linux"  "@_ZN8CTFKnife14DisguiseOnKillEv"
 			 "windows" "\x55\x8B\xEC\x51\x56\x8B\xF1\x8B\x96\x00\x08\x00\x00"
+			}
+			"CTFLunchBox::ApplyBiteEffects"
+			{
+				"library" "server"
+				"linux"  "@_ZN11CTFLunchBox16ApplyBiteEffectsEP9CTFPlayer"
+				"windows" "\x55\x8B\xEC\x51\x53\x8B\xD9\x56\x57\x6A\x01"
 			}
 			"CTFGameStats::Event_PlayerFiredWeapon"
 			{
@@ -452,6 +464,24 @@
 					}
 				}
 			}
+			"CTFPlayer::TakeHealth"
+			{
+				"signature"	"CTFPlayer::TakeHealth"
+				"callconv"	"thiscall"
+				"return"	"int"
+				"this"		"entity"
+				"arguments"
+				{
+					"flHealth"
+					{
+						"type"	"float"
+					}
+					"bitsDamageType"
+					{
+						"type"	"int"
+					}
+				}
+			}
 			"CTFPlayerClassShared::CanBuildObject"
 			{
 				"signature"	"CTFPlayerClassShared::CanBuildObject"
@@ -472,6 +502,20 @@
 			 "callconv" "thiscall"
 			 "return" "void"
 			 "this" "entity"
+			}
+			"CTFLunchBox::ApplyBiteEffects"
+			{
+				"signature" "CTFLunchBox::ApplyBiteEffects"
+				"callconv" "thiscall"
+				"return" "void"
+				"this" "entity"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type"	"cbaseentity"
+					}
+				}
 			}
 			"CTFGameStats::Event_PlayerFiredWeapon"
 			{

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -27,7 +27,6 @@ static int g_iWeaponGetLoadoutItem = -1;
 
 static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS+1];
 static int g_iHookIdClientCommand[TF_MAXPLAYERS+1];
-static int g_iHookIdTakeHealth[TF_MAXPLAYERS+1];
 static int g_iHookIdGiveAmmo[TF_MAXPLAYERS+1];
 static int g_iHookIdForceRespawnPre[TF_MAXPLAYERS+1];
 static int g_iHookIdForceRespawnPost[TF_MAXPLAYERS+1];


### PR DESCRIPTION
Fixes #40 
The Dalokohs Bar's healing type is `DMG_IGNORE_MAXHEALTH` for some reason, and the [max overheal you can achieve with it is hard-coded](https://github.com/TheAlePower/TeamFortress2/blob/master/tf2_src/game/shared/tf/tf_weapon_lunchbox.cpp#L353-L357). We change this to `DMG_GENERIC` to prevent the overheal.
The only time it should overheal is when your max hp is reduced by the Gloves of Running Urgently. I was unable to find a way to measure how much max hp a player has lost, so for now this can't overheal you to your 'real' max hp after switching off of the GRU.