### PR TITLE
Add custom weapons support

### DIFF
--- a/configs/randomizer/weapons.cfg
+++ b/configs/randomizer/weapons.cfg
@@ -2,6 +2,23 @@
 {
 	"Primary"
 	{
+//		"weapon"
+//		{
+//			"index"		"228"
+//			"name"		"Weapon_ArmyOfOne"
+//			"classname"	"tf_weapon_rocketlauncher"
+//			"attrib"
+//			{
+//				"damage bonus"					"5.0"
+//				"clip size penalty"				"0.25"
+//				"heal on hit for rapidfire"		"0.0"
+//				"maxammo primary reduced"		"0.0"
+//				"Blast radius increased"		"3.0"
+//				"Projectile speed decreased"	"0.3"
+//				"use large smoke explosion"		"1.0"
+//			}
+//		}
+		
 		"13"	"Weapon_Scattergun"
 		"45"	"Weapon_ForceANature"
 		"220"	"Weapon_Shortstop"

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -136,11 +136,23 @@
 				"linux"		"@_ZN9CTFPlayer15ValidateWeaponsEP19TFPlayerClassData_tb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x38\x81\x65\xE4\xFF\xFF\x0F\xFF"
 			}
+			"CTFPlayer::ValidateWearables"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer17ValidateWearablesEP19TFPlayerClassData_t"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x1C\x81\x65\xE8\xFF\xFF\x0F\xFF"
+			}
 			"CTFPlayer::ManageBuilderWeapons"
 			{
 				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer20ManageBuilderWeaponsEP19TFPlayerClassData_t"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x28\x53\x56\x8B\xF1\xC7\x45\xF0\x30\x00\x00\x00"
+			}
+			"CTFPlayer::ItemsMatch"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer10ItemsMatchEP19TFPlayerClassData_tP13CEconItemViewS3_P13CTFWeaponBase"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x0C\x57\x8B\x7D\x10"
 			}
 			"CTFPlayer::AddObject"
 			{
@@ -298,8 +310,8 @@
 			}
 			"CTFPlayer::ClientCommand"
 			{
-			 "linux"  "373"
-			 "windows" "372"
+				"linux"		"373"
+				"windows"	"372"
 			}
 			"CGameRules::FrameUpdatePostEntityThink"
 			{
@@ -375,6 +387,20 @@
 					}
 				}
 			}
+			"CTFPlayer::ValidateWearables"
+			{
+				"signature"	"CTFPlayer::ValidateWearables"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pData"
+					{
+						"type"	"objectptr"
+					}
+				}
+			}
 			"CTFPlayer::ManageBuilderWeapons"
 			{
 				"signature"	"CTFPlayer::ManageBuilderWeapons"
@@ -386,6 +412,32 @@
 					"pData"
 					{
 						"type"	"objectptr"
+					}
+				}
+			}
+			"CTFPlayer::ItemsMatch"
+			{
+				"signature"	"CTFPlayer::ItemsMatch"
+				"callconv"	"thiscall"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"pData"		//TFPlayerClassData_t *
+					{
+						"type"	"objectptr"
+					}
+					"pItem1"	//CEconItemView *
+					{
+						"type"	"objectptr"
+					}
+					"pItem2"	//CEconItemView *
+					{
+						"type"	"objectptr"
+					}
+					"pWeapon"	//CTFWeaponBase *
+					{
+						"type"	"cbaseentity"
 					}
 				}
 			}

--- a/scripting/randomizer/controls.sp
+++ b/scripting/randomizer/controls.sp
@@ -111,19 +111,12 @@ void Controls_RefreshClient(int iClient)
 		g_flControlsCooldown[iClient][iSlot] = 0.0;
 		
 		for (Button nButton; nButton < Button_MAX; nButton++)
-			g_bControlsButton[iClient][iSlot][nButton] = false;
-	}
-	
-	int iWeapon;
-	int iPos;
-	while (TF2_GetItem(iClient, iWeapon, iPos))
-	{
-		int iSlot = TF2_GetSlot(iWeapon);
-		int iIndex = GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex");
-		
-		for (Button nButton; nButton < Button_MAX; nButton++)
-			if (g_controlsInfo[nButton].weaponWhitelist.IsIndexAllowed(iIndex))
-				g_bControlsButton[iClient][iSlot][nButton] = true;
+		{
+			if (g_ClientWeaponInfo[iClient][iSlot].GetItem() == INVALID_ENT_REFERENCE)
+				g_bControlsButton[iClient][iSlot][nButton] = false;
+			else
+				g_bControlsButton[iClient][iSlot][nButton] = g_controlsInfo[nButton].weaponWhitelist.IsAllowed(g_ClientWeaponInfo[iClient][iSlot]);
+		}
 	}
 }
 

--- a/translations/randomizer.phrases.txt
+++ b/translations/randomizer.phrases.txt
@@ -1048,5 +1048,10 @@
 	{
 		"en"		"Cloak and Dagger"
 	}
+	
+	"Weapon_ArmyOfOne"
+	{
+		"en"		"Army Of One"
+	}
 }
 


### PR DESCRIPTION
There a lot of changes here and not finished yet, just want to push current progress.

This adds custom weapons support from #51, supports name, index, classname and attributes.
No support for custom model and viewmodels, those are a mess to work with and i'm not sure if there enough demands for it.

Default config won't have any starter custom weapons, but server owners can add themselves in config, with Army of One as an example on how to add custom weapons in config.

Also updated commands where player don't respawn, but instead regenerated on weapon/class change. `sm_rndweapon` also supports having weapon name as instead of def index in args, eg `sm_rndweapon @me 1 Righteous Bison` would be the same as `sm_rndweapon @me 1 442`