### PR TITLE
Fix issues related to having multiple weapons that use m_flRageMeter

### DIFF
--- a/configs/randomizer/huds.cfg
+++ b/configs/randomizer/huds.cfg
@@ -58,7 +58,7 @@
 		}
 		
 		"entity"	"client"
-		"type"		"float"
+		"type"		"ragemeter"
 		"min"		"0.0"
 		"text"		"Huds_RageMeter"
 	}

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -259,6 +259,11 @@
 		}
 		"Offsets"
 		{
+			"CBaseEntity::GetBaseEntity"
+			{
+				"linux"		"6"
+				"windows"	"5"
+			}
 			"CBaseCombatCharacter::GiveAmmo"
 			{
 				"linux"		"256"

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -232,6 +232,24 @@
 				"linux"		"@_ZN12CTFGameStats23Event_PlayerFiredWeaponEP9CTFPlayerb"
 				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x56\x8B\x75\x08"
 			}
+			"CTFPlayerShared::UpdateRageBuffsAndRage"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFPlayerShared22UpdateRageBuffsAndRageEv"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x53\x8B\xD9\x8B\x8B\x90\x01\x00\x00\x8B\x01\x8B\x80\x04\x01\x00\x00\xFF\xD0\x84\xC0\x2A\x2A\x8B\xCB"
+			}
+			"CTFPlayerShared::ModifyRage"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFPlayerShared10ModifyRageEf"
+				"windows"	"\x55\x8B\xEC\xF3\x0F\x10\x81\x8C\x02\x00\x00"
+			}
+			"CTFPlayerShared::ActivateRageBuff"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFPlayerShared16ActivateRageBuffEP11CBaseEntityi"
+				"windows"	"\x55\x8B\xEC\x51\xF3\x0F\x10\x05\x2A\x2A\x2A\x2A\x56\x8B\xF1"
+			}
 			"HandleRageGain"
 			{
 				"library"	"server"
@@ -532,6 +550,45 @@
 					"bCritical"
 					{
 						"type"	"bool"
+					}
+				}
+			}
+			"CTFPlayerShared::UpdateRageBuffsAndRage"
+			{
+				"signature"	"CTFPlayerShared::UpdateRageBuffsAndRage"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"address"
+			}
+			"CTFPlayerShared::ModifyRage"
+			{
+				"signature"	"CTFPlayerShared::ModifyRage"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"flDelta"
+					{
+						"type"	"float"
+					}
+				}
+			}
+			"CTFPlayerShared::ActivateRageBuff"
+			{
+				"signature"	"CTFPlayerShared::ActivateRageBuff"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"pItem"
+					{
+						"type"	"cbaseentity"
+					}
+					"iBuffType"
+					{
+						"type"	"int"
 					}
 				}
 			}

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -242,10 +242,6 @@ Handle g_hTimerClientHud[TF_MAXPLAYERS];
 
 int g_iClientEurekaTeleporting;
 
-float g_flRageMeter[TF_MAXPLAYERS+1][CLASS_MAX+1];
-bool g_bRageDraining[TF_MAXPLAYERS+1][CLASS_MAX+1];
-
-
 #include "randomizer/controls.sp"
 #include "randomizer/huds.sp"
 #include "randomizer/viewmodels.sp"
@@ -255,6 +251,7 @@ bool g_bRageDraining[TF_MAXPLAYERS+1][CLASS_MAX+1];
 #include "randomizer/commands.sp"
 #include "randomizer/dhook.sp"
 #include "randomizer/patch.sp"
+#include "randomizer/ragemeter.sp"
 #include "randomizer/sdkcall.sp"
 #include "randomizer/sdkhook.sp"
 #include "randomizer/stocks.sp"

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -221,6 +221,7 @@ bool g_bEnabled;
 bool g_bTF2Items;
 bool g_bAllowGiveNamedItem;
 int g_iOffsetItemDefinitionIndex = -1;
+int g_iOffsetPlayerShared;
 
 ConVar g_cvEnabled;
 ConVar g_cvRandomClass;
@@ -278,6 +279,7 @@ public void OnPluginStart()
 	DHook_Init(hGameData);
 	SDKCall_Init(hGameData);
 	g_iOffsetItemDefinitionIndex = hGameData.GetOffset("CEconItemView::m_iItemDefinitionIndex");
+	g_iOffsetPlayerShared = FindSendPropInfo("CTFPlayer", "m_Shared");
 	
 	delete hGameData;
 	

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -242,6 +242,10 @@ Handle g_hTimerClientHud[TF_MAXPLAYERS];
 
 int g_iClientEurekaTeleporting;
 
+float g_flRageMeter[TF_MAXPLAYERS+1][CLASS_MAX+1];
+bool g_bRageDraining[TF_MAXPLAYERS+1][CLASS_MAX+1];
+
+
 #include "randomizer/controls.sp"
 #include "randomizer/huds.sp"
 #include "randomizer/viewmodels.sp"

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -35,8 +35,6 @@ static int g_iHookIdForceRespawnPost[TF_MAXPLAYERS+1];
 static int g_iHookIdEquipWearable[TF_MAXPLAYERS+1];
 static bool g_bDoClassSpecialSkill[TF_MAXPLAYERS+1];
 static bool g_bApplyBiteEffectsChocolate[TF_MAXPLAYERS+1];
-static float g_flRageMeter[TF_MAXPLAYERS+1][CLASS_MAX+1];
-static bool g_bRageDraining[TF_MAXPLAYERS+1][CLASS_MAX+1];
 
 static int g_iDHookGamerulesPre;
 static int g_iDHookGamerulesPost;

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -599,7 +599,7 @@ public float Rage_GetBuffTypeAttribute(int iClient)
 
 public MRESReturn DHook_UpdateRageBuffsAndRagePre(Address pPlayerShared)
 {
-	int iClient = GetClientFromAddress(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
+	int iClient = SDKCall_GetBaseEntity(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
 	if (g_bSkipUpdateRageBuffsAndRage || iClient <= 0 || iClient > TF_MAXPLAYERS)
 		return MRES_Ignored;
 
@@ -655,21 +655,21 @@ public void Frame_UpdateRageBuffsAndRage(int iClient)
 
 public MRESReturn DHook_ModifyRagePre(Address pPlayerShared, Handle hParams)
 {
-	int iClient = GetClientFromAddress(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
+	int iClient = SDKCall_GetBaseEntity(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
 	if(iClient && g_nClassGainingRage != TFClass_Unknown)
 		Rage_LoadRageProps(iClient, g_nClassGainingRage);
 }
 
 public MRESReturn DHook_ModifyRagePost(Address pPlayerShared, Handle hParams)
 {
-	int iClient = GetClientFromAddress(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
+	int iClient = SDKCall_GetBaseEntity(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
 	if(iClient && g_nClassGainingRage != TFClass_Unknown)
 		Rage_SaveRageProps(iClient, g_nClassGainingRage);
 }
 
 public MRESReturn DHook_ActivateRageBuffPre(Address pPlayerShared, Handle hParams)
 {
-	int iClient = GetClientFromAddress(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
+	int iClient = SDKCall_GetBaseEntity(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
 	if(!iClient)
 		return MRES_Ignored;
 	
@@ -690,7 +690,7 @@ public MRESReturn DHook_ActivateRageBuffPre(Address pPlayerShared, Handle hParam
 
 public MRESReturn DHook_ActivateRageBuffPost(Address pPlayerShared, Handle hParams)
 {
-	int iClient = GetClientFromAddress(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
+	int iClient = SDKCall_GetBaseEntity(pPlayerShared - view_as<Address>(g_iOffsetPlayerShared));
 	if(!iClient)
 		return MRES_Ignored;
 	

--- a/scripting/randomizer/huds.sp
+++ b/scripting/randomizer/huds.sp
@@ -318,7 +318,20 @@ public Action Huds_ClientDisplay(Handle hTimer, int iClient)
 					case HudType_Float, HudType_Time:
 					{
 						float flVal;
-						if (hudInfo.GetEntPropFloat(iEntity, flVal))
+						bool bHasValue;
+						if(StrEqual(hudInfo.sNetprop, "m_flRageMeter"))
+						{
+							TFClassType nClass = TF2_GetDefaultClassFromItem(iWeapon);
+							flVal = g_flRageMeter[iClient][nClass];
+							//Redo the logic normally done in hudInfo.GetEntPropFloat
+							flVal *= hudInfo.flMultiply;
+							flVal += hudInfo.flAdd;
+							bHasValue = (!hudInfo.bMin || flVal > hudInfo.flMin) && (!hudInfo.bMax || flVal < hudInfo.flMax);
+						}
+						else 
+							bHasValue = hudInfo.GetEntPropFloat(iEntity, flVal);
+						
+						if (bHasValue)
 							Format(sDisplay, sizeof(sDisplay), "%s: %T", sDisplay, hudInfo.sText, iClient, flVal);
 					}
 				}

--- a/scripting/randomizer/huds.sp
+++ b/scripting/randomizer/huds.sp
@@ -329,7 +329,7 @@ public Action Huds_ClientDisplay(Handle hTimer, int iClient)
 					case HudType_RageMeter:
 					{
 						TFClassType nClass = TF2_GetDefaultClassFromItem(iWeapon);
-						flVal = g_flRageMeter[iClient][nClass];
+						flVal = Rage_GetClassMeter(iClient, nClass);
 					}
 				}
 				

--- a/scripting/randomizer/ragemeter.sp
+++ b/scripting/randomizer/ragemeter.sp
@@ -1,0 +1,55 @@
+static float g_flRageMeter[TF_MAXPLAYERS+1][CLASS_MAX+1];
+static bool g_bRageDraining[TF_MAXPLAYERS+1][CLASS_MAX+1];
+
+//Next several functions work together to effectively seperate m_flRageMeter between weapons
+//Whenever it matters, we change the players m_flRageMeter and m_bRageDraining to whatever it should be for the weapon's class
+
+void Rage_LoadRageProps(int iClient, TFClassType nClass)
+{
+	int iClass = view_as<int>(nClass);
+	float flRageMeter = g_flRageMeter[iClient][iClass];
+	bool bRageDraining = g_bRageDraining[iClient][iClass];
+ 
+	SetEntPropFloat(iClient, Prop_Send, "m_flRageMeter", flRageMeter);
+	SetEntProp(iClient, Prop_Send, "m_bRageDraining", view_as<int>(bRageDraining));
+}
+
+void Rage_SaveRageProps(int iClient, TFClassType nClass)
+{
+	int iClass = view_as<int>(nClass);
+	float flRageMeter = GetEntPropFloat(iClient, Prop_Send, "m_flRageMeter");
+	bool bRageDraining = !!GetEntProp(iClient, Prop_Send, "m_bRageDraining");
+	
+	g_flRageMeter[iClient][iClass] = flRageMeter;
+	g_bRageDraining[iClient][iClass] = bRageDraining;
+	
+	//Revert back to the props for the current weapon's class, to allow activating rage
+	int iWeapon = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
+	if (iWeapon > MaxClients)
+		Rage_LoadRageProps(iClient, TF2_GetDefaultClassFromItem(iWeapon));
+	
+}
+
+//Rage type is determined by the "mod soldier buff type" attribute on the player
+//That takes into account each weapon equipped, resulting in the sum not being the correct rage type
+//This returns the sum of the attribute on each weapon, so that we can correct it ourselves
+
+float Rage_GetBuffTypeAttribute(int iClient)
+{
+	float flTotal;
+	int iWeapon;
+	int iPos;
+	while (TF2_GetItem(iClient, iWeapon, iPos))
+	{
+		float flVal;
+		TF2_WeaponFindAttribute(iWeapon, "mod soldier buff type", flVal);
+		flTotal += flVal;
+	}
+	
+	return flTotal;
+}
+
+float Rage_GetClassMeter(int iClient, TFClassType nClass)
+{
+	return g_flRageMeter[iClient][nClass];
+}

--- a/scripting/randomizer/sdkcall.sp
+++ b/scripting/randomizer/sdkcall.sp
@@ -3,6 +3,7 @@ static Handle g_hSDKRemoveObject;
 static Handle g_hSDKDoClassSpecialSkill;
 static Handle g_hSDKEndClassSpecialSkill;
 static Handle g_hSDKGetLoadoutItem;
+static Handle g_hSDKUpdateRageBuffsAndRage;
 static Handle g_hSDKHandleRageGain;
 static Handle g_hSDKGetSlot;
 static Handle g_hSDKEquipWearable;
@@ -47,6 +48,12 @@ public void SDKCall_Init(GameData hGameData)
 	g_hSDKGetLoadoutItem = EndPrepSDKCall();
 	if (!g_hSDKGetLoadoutItem)
 		SetFailState("Failed to create call: CTFPlayer::GetLoadoutItem");
+	
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayerShared::UpdateRageBuffsAndRage");
+	g_hSDKUpdateRageBuffsAndRage = EndPrepSDKCall();
+	if (!g_hSDKUpdateRageBuffsAndRage)
+		SetFailState("Failed to create call: CTFPlayerShared::UpdateRageBuffsAndRage");
 	
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "HandleRageGain");
@@ -107,6 +114,11 @@ bool SDKCall_EndClassSpecialSkill(int iClient)
 Address SDKCall_GetLoadoutItem(int iClient, TFClassType nClass, int iSlot, bool bReportWhitelistFails = false)
 {
 	return SDKCall(g_hSDKGetLoadoutItem, iClient, nClass, iSlot, bReportWhitelistFails);
+}
+
+void SDKCall_UpdateRageBuffsAndRage(Address pPlayerShared)
+{
+	SDKCall(g_hSDKUpdateRageBuffsAndRage, pPlayerShared);
 }
 
 void SDKCall_HandleRageGain(int iClient, int iRequiredBuffFlags, float flDamage, float fInverseRageGainScale)

--- a/scripting/randomizer/sdkcall.sp
+++ b/scripting/randomizer/sdkcall.sp
@@ -1,3 +1,4 @@
+static Handle g_hSDKGetBaseEntity;
 static Handle g_hSDKAddObject;
 static Handle g_hSDKRemoveObject;
 static Handle g_hSDKDoClassSpecialSkill;
@@ -11,19 +12,26 @@ static Handle g_hSDKGiveNamedItem;
 
 public void SDKCall_Init(GameData hGameData)
 {
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBaseEntity::GetBaseEntity");
+	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
+	g_hSDKGetBaseEntity = EndPrepSDKCall();
+	if (!g_hSDKGetBaseEntity)
+		LogError("Failed to create call: CBaseEntity::GetBaseEntity");
+	
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::AddObject");
 	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
 	g_hSDKAddObject = EndPrepSDKCall();
-	if (g_hSDKAddObject == null)
-		LogMessage("Failed to create call: CTFPlayer::AddObject");
+	if (!g_hSDKAddObject)
+		LogError("Failed to create call: CTFPlayer::AddObject");
 	
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::RemoveObject");
 	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
 	g_hSDKRemoveObject = EndPrepSDKCall();
-	if (g_hSDKRemoveObject == null)
-		LogMessage("Failed to create call: CTFPlayer::RemoveObject");
+	if (!g_hSDKRemoveObject)
+		LogError("Failed to create call: CTFPlayer::RemoveObject");
 	
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::DoClassSpecialSkill");
@@ -47,13 +55,13 @@ public void SDKCall_Init(GameData hGameData)
 	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
 	g_hSDKGetLoadoutItem = EndPrepSDKCall();
 	if (!g_hSDKGetLoadoutItem)
-		SetFailState("Failed to create call: CTFPlayer::GetLoadoutItem");
+		LogError("Failed to create call: CTFPlayer::GetLoadoutItem");
 	
 	StartPrepSDKCall(SDKCall_Raw);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayerShared::UpdateRageBuffsAndRage");
 	g_hSDKUpdateRageBuffsAndRage = EndPrepSDKCall();
 	if (!g_hSDKUpdateRageBuffsAndRage)
-		SetFailState("Failed to create call: CTFPlayerShared::UpdateRageBuffsAndRage");
+		LogError("Failed to create call: CTFPlayerShared::UpdateRageBuffsAndRage");
 	
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "HandleRageGain");
@@ -63,7 +71,7 @@ public void SDKCall_Init(GameData hGameData)
 	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
 	g_hSDKHandleRageGain = EndPrepSDKCall();
 	if (!g_hSDKHandleRageGain)
-		SetFailState("Failed to create call: HandleRageGain");
+		LogError("Failed to create call: HandleRageGain");
 	
 	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBaseCombatWeapon::GetSlot");
@@ -88,7 +96,12 @@ public void SDKCall_Init(GameData hGameData)
 	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
 	g_hSDKGiveNamedItem = EndPrepSDKCall();
 	if (!g_hSDKGiveNamedItem)
-		SetFailState("Failed to create call: CTFPlayer::GiveNamedItem");
+		LogError("Failed to create call: CTFPlayer::GiveNamedItem");
+}
+
+int SDKCall_GetBaseEntity(Address pEntity)
+{
+	return SDKCall(g_hSDKGetBaseEntity, pEntity);
 }
 
 void SDKCall_AddObject(int iClient, int iObject)

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -142,6 +142,13 @@ public void Client_WeaponEquipPost(int iClient, int iWeapon)
 	Huds_RefreshClient(iClient);
 }
 
+public void Client_WeaponSwitchPost(int iClient, int iWeapon)
+{
+	TFClassType nClass = TF2_GetDefaultClassFromItem(iWeapon);
+	if (nClass != TFClass_Unknown)
+		Rage_LoadRageProps(iClient, nClass);
+}
+
 public void Weapon_SpawnPost(int iWeapon)
 {
 	Ammo_OnWeaponSpawned(iWeapon);

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -438,3 +438,12 @@ stock int FindStringIndex2(int iTableId, const char[] sParticle)
 
 	return INVALID_STRING_INDEX;
 }
+
+stock int GetClientFromAddress(Address pPlayer)
+{
+	for(int i = 1; i <= MaxClients; i++)
+		if(IsClientInGame(i) && GetEntityAddress(i) == pPlayer)
+			return i;
+	
+	return -1;
+}

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -438,12 +438,3 @@ stock int FindStringIndex2(int iTableId, const char[] sParticle)
 
 	return INVALID_STRING_INDEX;
 }
-
-stock int GetClientFromAddress(Address pPlayer)
-{
-	for(int i = 1; i <= MaxClients; i++)
-		if(IsClientInGame(i) && GetEntityAddress(i) == pPlayer)
-			return i;
-	
-	return -1;
-}


### PR DESCRIPTION
Fixes #14 , #30  (sort of),  and part of #7 

This is not quite ready to be merged, but I did want to share my progress and receive feedback.
There's 3 things I want addressed.

First, I'm a little worried that the code in `DHook_UpdateRageBuffsAndRage` might be a little too intensive. Specifically, `GetClientFromAddress`; While it should be fine for most functions, using it in an update function results in ~500 calls to `GetEntityAddress` each frame on a full server. I did try it, and noticed no notable spikes in server lag/cpu usage, but I would still prefer a more efficient method.

Second, activating the rage buff of one item, then another, results in the first buff ending, although rage will still drain. I think this is caused by `ActivateRageBuff` [always using the same buff slot](https://github.com/TheAlePower/TeamFortress2/blob/1b81dded673d49adebf4d0958e52236ecc28a956/tf2_src/game/shared/tf/tf_player_shared.cpp#L13102). Preferable to #30 but would still be nice to fix.

Lastly, `huds.sp` will need to be updated to show our own rage meter for the weapon's class, rather than reading the netprop from the player.

I have allow edits by maintainers enabled, feel free to change whatever you see fit.