### PR TITLE
Reset rage meters on client disconnect

### DIFF
--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -393,6 +393,7 @@ public void OnClientDisconnect(int iClient)
 	g_hTimerClientHud[iClient] = null;
 	DHook_UnhookGiveNamedItem(iClient);
 	DHook_UnhookClient(iClient);
+	Rage_ResetRageMeters(iClient);
 }
 
 public void OnPlayerRunCmdPost(int iClient, int iButtons, int iImpulse, const float vecVel[3], const float vecAngles[3], int iWeapon, int iSubtype, int iCmdNum, int iTickCount, int iSeed, const int iMouse[2]) 

--- a/scripting/randomizer/ragemeter.sp
+++ b/scripting/randomizer/ragemeter.sp
@@ -30,6 +30,15 @@ void Rage_SaveRageProps(int iClient, TFClassType nClass)
 	
 }
 
+void Rage_ResetRageMeters(int iClient)
+{
+	for(int i = CLASS_MIN; i <= CLASS_MAX; i++)
+	{
+		g_flRageMeter[iClient][i] = 0.0;
+		g_bRageDraining[iClient][i] = false;
+	}
+}
+
 //Rage type is determined by the "mod soldier buff type" attribute on the player
 //That takes into account each weapon equipped, resulting in the sum not being the correct rage type
 //This returns the sum of the attribute on each weapon, so that we can correct it ourselves


### PR DESCRIPTION
A small oversight from the last commit, now we properly clear our rage meters when a client leaves the server, preventing someone from getting that rage just by joining.