### PR TITLE
Add convars for weapon-class limit and teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,17 @@ TF2 Gamemode where everyone plays as random class with random weapons, a rewritt
 - `randomizer_enabled`: Enable/Disable entire randomizer plugin, another option for load/unload plugins.
 - `randomizer_droppedweapons`: Enable/Disable dropped weapons.
 - `randomizer_huds`: Enable/Disable weapon huds.
+- `randomizer_weaponsfromclass`: Whenever generated weapon should only be whatever class can normally equip.
 - `randomizer_randomclass`/`randomizer_randomweapons`: Modes to change player class/weapon randomization.
-  - 0: No randomizes, allowing players to freely change class/weapon themself.
-  - 1: Randomizes on death.
-  - 2: Randomizes on new round.
+  - 0: No randomizes, allowing players to freely change class/weapon themself
+  - 1: Randomizes on death
+  - 2: Randomizes on new round
   - 3: Every team get same class/weapon randomizes every round
   - 4: Everyone get same class/weapon randomizes every round
+- `randomizer_teamclass`/`randomizer_teamweapons`: Teams to randomize class/weapon.
+  - 1: Both teams
+  - 2: Only red team
+  - 3: Only blu team
 
 ## Commands
 - `sm_cantsee`: Set your active weapon transparent or fully visible, for everyone

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -385,7 +385,7 @@ stock bool ItemIsAllowed(int iIndex)
 
 stock bool CanKeepWeapon(int iClient, const char[] sClassname, int iIndex)
 {
-	if (g_bAllowGiveNamedItem || g_cvRandomWeapons.IntValue == Mode_None)
+	if (g_bAllowGiveNamedItem || !IsWeaponRandomized(iClient))
 		return true;
 	
 	//Allow grappling hook and passtime gun


### PR DESCRIPTION
README, #66 and #67 should explain enough what new convars does, some extra notes though:
- `randomizer_weaponsfromclass` does NOT disable hook fixes as I suggested in #66, turns out quite a bit of work needed to do to make it possible.
- `randomizer_randomclass`/`randomizer_randomweapons` only have `1` as any team. `0` is not an option as I suggested in #67, in-case I may want to use `0` for something else in the future.