### PR TITLE
Add support for random cosmetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ TF2 Gamemode where everyone plays as random class with random weapons, a rewritt
 - `randomizer_droppedweapons`: Enable/Disable dropped weapons.
 - `randomizer_huds`: Enable/Disable weapon huds.
 - `randomizer_weaponsfromclass`: Whenever generated weapon should only be whatever class can normally equip.
-- `randomizer_cosmeticsconflicts`: Whenever generated cosmetics check for possible conflicts.
 - `randomizer_randomcosmetics`: How many cosmetics to randomly generate, -1 for no cosmetic randomization.
+- `randomizer_cosmeticsconflicts`: Whenever generated cosmetics should check for possible conflicts.
 - `randomizer_randomclass`/`randomizer_randomweapons`: Modes to change player class/weapon randomization.
   - 0: No randomizes, allowing players to freely change class/weapon themself
   - 1: Randomizes on death

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ TF2 Gamemode where everyone plays as random class with random weapons, a rewritt
 - `randomizer_droppedweapons`: Enable/Disable dropped weapons.
 - `randomizer_huds`: Enable/Disable weapon huds.
 - `randomizer_weaponsfromclass`: Whenever generated weapon should only be whatever class can normally equip.
+- `randomizer_cosmeticsconflicts`: Whenever generated cosmetics check for possible conflicts.
+- `randomizer_randomcosmetics`: How many cosmetics to randomly generate, -1 for no cosmetic randomization.
 - `randomizer_randomclass`/`randomizer_randomweapons`: Modes to change player class/weapon randomization.
   - 0: No randomizes, allowing players to freely change class/weapon themself
   - 1: Randomizes on death
   - 2: Randomizes on new round
   - 3: Every team get same class/weapon randomizes every round
   - 4: Everyone get same class/weapon randomizes every round
-- `randomizer_teamclass`/`randomizer_teamweapons`: Teams to randomize class/weapon.
+- `randomizer_teamclass`/`randomizer_teamweapons`/`randomizer_teamcosmetics`: Teams to randomize class/weapon/cosmetic.
   - 1: Both teams
   - 2: Only red team
   - 3: Only blu team

--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -136,6 +136,12 @@
 				"linux"		"@_ZN9CTFPlayer15ValidateWeaponsEP19TFPlayerClassData_tb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x38\x81\x65\xE4\xFF\xFF\x0F\xFF"
 			}
+			"CTFPlayer::ValidateWearables"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer17ValidateWearablesEP19TFPlayerClassData_t"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x1C\x81\x65\xE8\xFF\xFF\x0F\xFF"
+			}
 			"CTFPlayer::ManageBuilderWeapons"
 			{
 				"library"	"server"
@@ -395,6 +401,20 @@
 					"bResetWeapons"
 					{
 						"type"	"bool"
+					}
+				}
+			}
+			"CTFPlayer::ValidateWearables"
+			{
+				"signature"	"CTFPlayer::ValidateWearables"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pData"
+					{
+						"type"	"objectptr"
 					}
 				}
 			}

--- a/scripting/randomizer/commands.sp
+++ b/scripting/randomizer/commands.sp
@@ -134,7 +134,7 @@ public Action Command_Weapon(int iClient, int iArgs)
 	GetCmdArg(2, sSlot, sizeof(sSlot));
 	GetCmdArg(3, sIndex, sizeof(sIndex));
 	
-	if (!StringToIntEx(sSlot, iSlot) || iSlot < 0 || iSlot > WeaponSlot_BuilderEngie)
+	if (!StringToIntEx(sSlot, iSlot) || iSlot < 0 || iSlot > WeaponSlot_Building)
 	{
 		ReplyToCommand(iClient, "Invalid slot '%s'", sSlot);
 		return Plugin_Handled;

--- a/scripting/randomizer/controls.sp
+++ b/scripting/randomizer/controls.sp
@@ -20,8 +20,8 @@ enum struct ControlsPassive
 
 static ControlsInfo g_controlsInfo[Button_MAX];
 static StringMap g_mControlsPassive;
-static bool g_bControlsButton[TF_MAXPLAYERS][WeaponSlot_BuilderEngie+1][view_as<int>(Button_MAX)];
-static float g_flControlsCooldown[TF_MAXPLAYERS][WeaponSlot_BuilderEngie+1];
+static bool g_bControlsButton[TF_MAXPLAYERS][WeaponSlot_Building+1][view_as<int>(Button_MAX)];
+static float g_flControlsCooldown[TF_MAXPLAYERS][WeaponSlot_Building+1];
 
 public void Controls_Init()
 {
@@ -106,7 +106,7 @@ bool Controls_GetTranslation(KeyValues kv, const char[] sName, const char[] sKey
 
 void Controls_RefreshClient(int iClient)
 {
-	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_InvisWatch; iSlot++)
+	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_PDA2; iSlot++)
 	{
 		g_flControlsCooldown[iClient][iSlot] = 0.0;
 		

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -48,6 +48,7 @@ public void DHook_Init(GameData hGameData)
 	DHook_CreateDetour(hGameData, "CTFPlayer::Taunt", DHook_TauntPre, DHook_TauntPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::CanAirDash", DHook_CanAirDashPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::ValidateWeapons", DHook_ValidateWeaponsPre, DHook_ValidateWeaponsPost);
+	DHook_CreateDetour(hGameData, "CTFPlayer::ValidateWearables", DHook_ValidateWearablesPre, _);
 	DHook_CreateDetour(hGameData, "CTFPlayer::ManageBuilderWeapons", DHook_ManageBuilderWeaponsPre, DHook_ManageBuilderWeaponsPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::DoClassSpecialSkill", DHook_DoClassSpecialSkillPre, DHook_DoClassSpecialSkillPost);
 	DHook_CreateDetour(hGameData, "CTFPlayer::EndClassSpecialSkill", DHook_EndClassSpecialSkillPre, DHook_EndClassSpecialSkillPost);
@@ -336,6 +337,16 @@ public MRESReturn DHook_ValidateWeaponsPost(int iClient, Handle hParams)
 	RevertClientClass(iClient);	//Reset from GetLoadoutItem hook
 }
 
+public MRESReturn DHook_ValidateWearablesPre(int iClient, Handle hParams)
+{
+	//This function validates both wearable weapons and cosmetics, but post_inventory_application hook should be able to handle wearable weapon fine
+	
+	if (IsCosmeticRandomized(iClient))
+		return MRES_Supercede;	//Dont create or destroy any cosmetics
+	
+	return MRES_Ignored;
+}
+
 public MRESReturn DHook_ManageBuilderWeaponsPre(int iClient, Handle hParams)
 {
 	if (IsWeaponRandomized(iClient))
@@ -482,7 +493,7 @@ public MRESReturn DHook_GetEntityForLoadoutSlotPre(int iClient, Handle hReturn, 
 		return MRES_Ignored;
 	
 	int iSlot = DHookGetParam(hParams, 1);
-	if (iSlot < 0 || iSlot > WeaponSlot_BuilderEngie)
+	if (iSlot < 0 || iSlot > WeaponSlot_Building)
 		return MRES_Ignored;
 	
 	//This function sucks as it have default class check, lets use GetPlayerWeaponSlot instead

--- a/scripting/randomizer/huds.sp
+++ b/scripting/randomizer/huds.sp
@@ -87,7 +87,7 @@ enum struct HudWeapon
 }
 
 static ArrayList g_aHuds;	//Arrays of HudInfo
-static HudWeapon g_hudWeapon[TF_MAXPLAYERS][WeaponSlot_InvisWatch+1];	//What to display for each weapons
+static HudWeapon g_hudWeapon[TF_MAXPLAYERS][WeaponSlot_PDA2+1];	//What to display for each weapons
 
 void Huds_Init()
 {
@@ -211,7 +211,7 @@ void Huds_Refresh()
 
 void Huds_RefreshClient(int iClient)
 {
-	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_InvisWatch; iSlot++)
+	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_PDA2; iSlot++)
 	{
 		delete g_hudWeapon[iClient][iSlot].aHudInfo;
 		
@@ -278,7 +278,7 @@ public Action Huds_ClientDisplay(Handle hTimer, int iClient)
 	
 	char sDisplay[512];
 	
-	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_InvisWatch; iSlot++)
+	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_PDA2; iSlot++)
 	{
 		int iWeapon = EntRefToEntIndex(g_hudWeapon[iClient][iSlot].iRef);
 		if (iWeapon <= MaxClients)

--- a/scripting/randomizer/weapons.sp
+++ b/scripting/randomizer/weapons.sp
@@ -1,7 +1,7 @@
 #define FILEPATH_CONFIG_WEAPONS "configs/randomizer/weapons.cfg"
 #define FILEPATH_CONFIG_RESKINS "configs/randomizer/reskins.cfg"
 
-static ArrayList g_aWeapons[CLASS_MAX+1][WeaponSlot_BuilderEngie+1];
+static ArrayList g_aWeapons[CLASS_MAX+1][WeaponSlot_Building+1];
 static StringMap g_mWeaponsName;
 static StringMap g_mWeaponsReskins;
 
@@ -26,11 +26,11 @@ public void Weapons_Refresh()
 	Weapons_LoadSlot(kv, "Primary", WeaponSlot_Primary);
 	Weapons_LoadSlot(kv, "Secondary", WeaponSlot_Secondary);
 	Weapons_LoadSlot(kv, "Melee", WeaponSlot_Melee);
-	Weapons_LoadSlot(kv, "PDABuild", WeaponSlot_PDABuild);
-	Weapons_LoadSlot(kv, "PDADestroy", WeaponSlot_PDADestroy);
-	Weapons_LoadSlot(kv, "Toolbox", WeaponSlot_BuilderEngie);
-	Weapons_LoadSlot(kv, "DisguiseKit", WeaponSlot_PDADisguise);
-	Weapons_LoadSlot(kv, "InvisWatch", WeaponSlot_InvisWatch);
+	Weapons_LoadSlot(kv, "PDABuild", WeaponSlot_PDA);
+	Weapons_LoadSlot(kv, "PDADestroy", WeaponSlot_PDA2);
+	Weapons_LoadSlot(kv, "Toolbox", WeaponSlot_Building);
+	Weapons_LoadSlot(kv, "DisguiseKit", WeaponSlot_PDA);
+	Weapons_LoadSlot(kv, "InvisWatch", WeaponSlot_PDA2);
 	
 	delete kv;
 	


### PR DESCRIPTION
3 new convars:
`randomizer_randomcosmetics`: How many cosmetics to randomly generate, -1 for no cosmetic randomization.
`randomizer_cosmeticsconflicts`: Whenever generated cosmetic should check for possible conflicts.
`randomizer_teamcosmetics`: Teams to randomize cosmetic, similar to `randomizer_teamclass` and `randomizer_teamweapons`.