### PR TITLE
Add convars for min amount of weapons in slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ TF2 Gamemode where everyone plays as random class with random weapons, a rewritt
 - `randomizer_enabled`: Enable/Disable entire randomizer plugin, another option for load/unload plugins.
 - `randomizer_droppedweapons`: Enable/Disable dropped weapons.
 - `randomizer_weaponsfromclass`: Whenever generated weapon should only be whatever class can normally equip.
-- `randomizer_weaponscount`: How many weapons to randomly generate regardless of slot, -1 for each slot (pimary, secondary and melee).
+- `randomizer_weaponscount`: How many weapons at minimum to randomly generate regardless of slot.
+- `randomizer_weaponscount_primary`/`randomizer_weaponscount_secondary`/`randomizer_weaponscount_melee`: How many weapons at minimum to randomly generate from specific slot.
 - `randomizer_randomcosmetics`: How many cosmetics to randomly generate, -1 for no cosmetic randomization.
 - `randomizer_cosmeticsconflicts`: Whenever generated cosmetics should check for possible conflicts.
 - `randomizer_huds`: Mode to display weapons from hud.

--- a/scripting/randomizer/event.sp
+++ b/scripting/randomizer/event.sp
@@ -1,6 +1,6 @@
 void Event_Init()
 {
-	HookEvent("teamplay_round_start", Event_RoundStart, EventHookMode_Pre);
+	HookEvent("teamplay_round_start", Event_RoundStart);
 	HookEvent("player_spawn", Event_PlayerSpawn);
 	HookEvent("post_inventory_application", Event_PlayerInventoryUpdate);
 	HookEvent("player_hurt", Event_PlayerHurt);
@@ -36,6 +36,8 @@ public Action Event_PlayerSpawn(Event event, const char[] sName, bool bDontBroad
 	int iClient = GetClientOfUserId(event.GetInt("userid"));
 	if (TF2_GetClientTeam(iClient) <= TFTeam_Spectator)
 		return;
+	
+	g_bClientRespawn[iClient] = false;	//Client respawned, dont need force respawn demand
 	
 	if (!IsCosmeticRandomized(iClient))
 		return;


### PR DESCRIPTION
Can now force everyone to have minimum amount of weapons from slot.
`randomizer_weaponscount` is updated to no longer support `-1` value in favour of using new slot convars all each at default value 1.