### PR TITLE
Fix Hitman's Heatmaker not gaining rage meter

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -4,7 +4,7 @@
 	{
 		"Addresses"
 		{
-			"Patch_HealthDemomanClassCheck"
+			"Patch_1"	//Demoman class check for eyelander health
 			{
 				"signature" "CTFPlayer::GetMaxHealthForBuffing"
 				"linux"
@@ -16,7 +16,7 @@
 					"offset"	"81"
 				}
 			}
-			"Patch_SpeedDemomanClassCheck"
+			"Patch_2"	//Demoman class check for eyelander speed and charging
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -28,7 +28,7 @@
 					"offset"	"692"
 				}
 			}
-			"Patch_SpeedMedic1ClassCheck"
+			"Patch_3"	//Medic class check for healing charging
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -40,7 +40,7 @@
 					"offset"	"979"
 				}
 			}
-			"Patch_SpeedMedic2ClassCheck"
+			"Patch_4"	//Medic class check for Overdose speed
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -52,7 +52,7 @@
 					"offset"	"1270"
 				}
 			}
-			"Patch_SpeedHeavyClassCheck"
+			"Patch_5"	//Heavy class check for steak speed
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -64,7 +64,7 @@
 					"offset"	"1436"
 				}
 			}
-			"Patch_SpeedScoutClassCheck"
+			"Patch_6"	//Scout class check for Baby Face Blaster and Crit-A-Cola speed
 			{
 				"signature" "CTFPlayer::TeamFortress_CalculateMaxSpeed"
 				"linux"
@@ -76,35 +76,86 @@
 					"offset"	"1519"
 				}
 			}
+			"Patch_7"	//Spy class check for Your Eternal Reward silent kill
+			{
+				"signature" "CTFPlayer::Event_KilledOther"
+				"linux"
+				{
+					"offset"	"468"
+				}
+				"windows"
+				{
+					"offset"	"685"
+				}
+			}
+			"Patch_8"	//Demoman class check for kill refilling meter
+			{
+				"signature" "CTFPlayer::Event_KilledOther"
+				"linux"
+				{
+					"offset"	"1379"
+				}
+				"windows"
+				{
+					"offset"	"1874"
+				}
+			}
+			"Patch_9"	//Sniper class check for Hitman's Heatmaker rage on kill
+			{
+				"signature" "CTFPlayer::Event_KilledOther"
+				"linux"
+				{
+					"offset"	"1388"
+				}
+				"windows"
+				{
+					"offset"	"2816"
+				}
+			}
 		}
 		"Keys"
 		{
-			"Patch_HealthDemomanClassCheck"
+			"Patch_1"
 			{
 				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
 				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
 			}
-			"Patch_SpeedDemomanClassCheck"
+			"Patch_2"
 			{
 				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
 				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
 			}
-			"Patch_SpeedMedic1ClassCheck"
+			"Patch_3"
 			{
 				"linux"		"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to NOP (skip)
 				"windows"	"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to NOP (skip)
 			}
-			"Patch_SpeedMedic2ClassCheck"
+			"Patch_4"
 			{
 				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
 				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
 			}
-			"Patch_SpeedHeavyClassCheck"
+			"Patch_5"
 			{
 				"linux"		"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to to NOP (skip)
 				"windows"	"\xEB"	// Replace 'jnz short' to 'jmp short' (always jump)
 			}
-			"Patch_SpeedScoutClassCheck"
+			"Patch_6"
+			{
+				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
+			}
+			"Patch_7"
+			{
+				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
+			}
+			"Patch_8"
+			{
+				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
+				"windows"	"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to to NOP (skip)
+			}
+			"Patch_9"
 			{
 				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
 				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
@@ -213,6 +264,12 @@
 				"library"	"server"
 				"linux"		"@_ZNK9CTFPlayer30TeamFortress_CalculateMaxSpeedEb"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x83\x3D\x2A\x2A\x2A\x2A\x00"
+			}
+			"CTFPlayer::Event_KilledOther"
+			{
+				"library"	"server"
+				"linux"		"@_ZN11CBasePlayer17Event_KilledOtherEP11CBaseEntityRK15CTakeDamageInfo"
+				"windows"	"\x55\x8B\xEC\x81\xEC\xA4\x00\x00\x00\x53\x56\x8B\x75\x0C"
 			}
 			"CTFPlayer::TakeHealth"
 			{

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -15,7 +15,7 @@
 
 #pragma newdecls required
 
-#define PLUGIN_VERSION			"1.8.1"
+#define PLUGIN_VERSION			"1.8.2"
 #define PLUGIN_VERSION_REVISION	"manual"
 
 #define TF_MAXPLAYERS	34	//32 clients + 1 for 0/world/console + 1 for replay/SourceTV
@@ -355,6 +355,7 @@ bool g_bFeignDeath[TF_MAXPLAYERS];
 bool g_bWeaponDecap[TF_MAXPLAYERS];
 Handle g_hTimerClientHud[TF_MAXPLAYERS];
 
+int g_iGainingRageWeapon = INVALID_ENT_REFERENCE;
 int g_iClientEurekaTeleporting;
 
 #include "randomizer/controls.sp"

--- a/scripting/randomizer/properties.sp
+++ b/scripting/randomizer/properties.sp
@@ -291,8 +291,6 @@ void Properties_UpdateRageBuffsAndRage(int iClient)
 	if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
 		return;
 	
-	
-	
 	Properies_CallRageMeter(iClient, SDKCall_UpdateRageBuffsAndRage, GetEntityAddress(iClient) + view_as<Address>(g_iOffsetPlayerShared));
 }
 

--- a/scripting/randomizer/properties.sp
+++ b/scripting/randomizer/properties.sp
@@ -286,6 +286,123 @@ void Properties_SaveRageProps(int iClient, int iWeapon)
 	Properties_SaveWeaponDataFloat(iClient, iWeapon, iOffset + 12);	//RageBuff.m_flNextBuffPulseTime
 }
 
+void Properties_UpdateRageBuffsAndRage(int iClient)
+{
+	if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
+		return;
+	
+	
+	
+	Properies_CallRageMeter(iClient, SDKCall_UpdateRageBuffsAndRage, GetEntityAddress(iClient) + view_as<Address>(g_iOffsetPlayerShared));
+}
+
+void Properties_ModifyRage(DataPack hPack) 
+{
+	hPack.Reset();
+	int iClient = GetClientFromSerial(hPack.ReadCell());
+	float flAdd = hPack.ReadFloat();
+	delete hPack;
+	
+	if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
+		return;
+	
+	Properies_CallRageMeter(iClient, SDKCall_ModifyRage, GetEntityAddress(iClient) + view_as<Address>(g_iOffsetPlayerShared), flAdd);
+}
+
+void Properties_HandleRageGain(DataPack hPack)
+{
+	hPack.Reset();
+	int iClient = GetClientFromSerial(hPack.ReadCell());
+	int iRequiredBuffFlags = hPack.ReadCell();
+	float flDamage = hPack.ReadFloat();
+	float fInverseRageGainScale = hPack.ReadFloat();
+	delete hPack;
+	
+	if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
+		return;
+	
+	Properies_CallRageMeter(iClient, SDKCall_HandleRageGain, iClient, iRequiredBuffFlags, flDamage, fInverseRageGainScale);
+}
+
+void Properies_CallRageMeter(int iClient, Function fCall, any nParam1 = 0, any nParam2 = 0, any nParam3 = 0, any nParam4 = 0)
+{
+	//All weapons using set_buff_type, generate_rage_on_dmg and generate_rage_on_heal attrib is tf_weapon and no wearables, for now...
+	int iMaxWeapons = GetMaxWeapons();
+	int[] iWeapons = new int[iMaxWeapons];
+	
+	//Get overall buff type from multiple weapons to subtract down for each ones
+	float flClientRageType = TF2_GetAttributeAdditive(iClient, "mod soldier buff type");
+	
+	//Remove all weapons so they don't interfere with its rage stats
+	for (int i = 0; i < iMaxWeapons; i++)
+	{
+		iWeapons[i] = GetEntPropEnt(iClient, Prop_Send, "m_hMyWeapons", i);
+		SetEntPropEnt(iClient, Prop_Send, "m_hMyWeapons", -1, i);
+	}
+	
+	bool bCalledClass[CLASS_MAX + 1];
+	
+	for (int i = 0; i < iMaxWeapons; i++)
+	{
+		if (iWeapons[i] == INVALID_ENT_REFERENCE)
+			continue;
+		
+		float flVal;
+		TFClassType nClass = TF2_GetDefaultClassFromItem(iWeapons[i]);
+		
+		//Prevent calling same class twice, but only if it not for rage meter
+		//Soldier, Pyro and Sniper(?) use rage meter, while Heavy, Engineer, Medic and Sniper use whatever else there
+		if (!TF2_WeaponFindAttribute(iWeapons[i], "mod soldier buff type", flVal) && bCalledClass[nClass])	//Must call TF2_WeaponFindAttribute for flVal
+			continue;
+		
+		//ModifyRage is expected to only be called for Hitman Heatmaker, only increase meter to it
+		if (fCall == SDKCall_ModifyRage && flVal != 6.0)
+			continue;
+		
+		bCalledClass[nClass] = true;
+		
+		if (fCall == SDKCall_UpdateRageBuffsAndRage)
+			TF2Attrib_SetByName(iClient, "mod soldier buff type", flVal - flClientRageType);
+		
+		bool bFocusCond;
+		if (TF2_IsPlayerInCondition(iClient, TFCond_FocusBuff) && (flVal != 6.0 || !Properties_GetWeaponPropInt(iWeapons[i], "m_bRageDraining")))
+		{
+			//Updating weapons thats not in focus effect, but client is will set weapon to draining
+			TF2_RemoveConditionFake(iClient, TFCond_FocusBuff);
+			bFocusCond = true;
+		}
+		
+		SetEntPropEnt(iClient, Prop_Send, "m_hMyWeapons", iWeapons[i], i);
+		Properties_LoadRageProps(iClient, iWeapons[i]);
+		
+		SetClientClass(iClient, nClass);
+		g_iGainingRageWeapon = iWeapons[i];
+		
+		Call_StartFunction(null, fCall);
+		Call_PushCell(nParam1);
+		Call_PushCell(nParam2);
+		Call_PushCell(nParam3);
+		Call_PushCell(nParam4);
+		Call_Finish();
+		
+		Properties_SaveRageProps(iClient, iWeapons[i]);
+		SetEntPropEnt(iClient, Prop_Send, "m_hMyWeapons", -1, i);
+		
+		if (bFocusCond)
+			TF2_AddConditionFake(iClient, TFCond_FocusBuff);
+		
+		if (fCall == SDKCall_UpdateRageBuffsAndRage)
+			TF2Attrib_RemoveByName(iClient, "mod soldier buff type");
+	}
+	
+	//Set it back
+	for (int i = 0; i < iMaxWeapons; i++)
+		SetEntPropEnt(iClient, Prop_Send, "m_hMyWeapons", iWeapons[i], i);
+	
+	RevertClientClass(iClient);
+	g_iGainingRageWeapon = INVALID_ENT_REFERENCE;
+}
+
 // Item charge meter
 
 void Properties_AddWeaponChargeMeter(int iClient, int iWeapon, float flValue)

--- a/scripting/randomizer/sdkcall.sp
+++ b/scripting/randomizer/sdkcall.sp
@@ -5,6 +5,7 @@ static Handle g_hSDKDoClassSpecialSkill;
 static Handle g_hSDKEndClassSpecialSkill;
 static Handle g_hSDKGetLoadoutItem;
 static Handle g_hSDKUpdateRageBuffsAndRage;
+static Handle g_hSDKModifyRage;
 static Handle g_hSDKHandleRageGain;
 static Handle g_hSDKWeaponCanSwitchTo;
 static Handle g_hSDKGetSlot;
@@ -63,6 +64,13 @@ public void SDKCall_Init(GameData hGameData)
 	g_hSDKUpdateRageBuffsAndRage = EndPrepSDKCall();
 	if (!g_hSDKUpdateRageBuffsAndRage)
 		LogError("Failed to create call: CTFPlayerShared::UpdateRageBuffsAndRage");
+	
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayerShared::ModifyRage");
+	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
+	g_hSDKModifyRage = EndPrepSDKCall();
+	if (!g_hSDKModifyRage)
+		LogError("Failed to create call: CTFPlayerShared::ModifyRage");
 	
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "HandleRageGain");
@@ -141,6 +149,11 @@ Address SDKCall_GetLoadoutItem(int iClient, TFClassType nClass, int iSlot, bool 
 void SDKCall_UpdateRageBuffsAndRage(Address pPlayerShared)
 {
 	SDKCall(g_hSDKUpdateRageBuffsAndRage, pPlayerShared);
+}
+
+void SDKCall_ModifyRage(Address pPlayerShared, float flAdd)
+{
+	SDKCall(g_hSDKModifyRage, pPlayerShared, flAdd);
 }
 
 void SDKCall_HandleRageGain(int iClient, int iRequiredBuffFlags, float flDamage, float fInverseRageGainScale)

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -42,12 +42,13 @@ void SDKHook_OnEntityCreated(int iEntity, const char[] sClassname)
 
 public Action Client_OnTakeDamage(int iVictim, int &iAttacker, int &iInflictor, float &flDamage, int &iDamageType, int &iWeapon, float vecDamageForce[3], float vecDamagePosition[3], int iDamageCustom)
 {
-	g_iAllowPlayerClass[iVictim]++;
+	//Allow IsPlayerClass for everyone, we want assister too which would be tough to get without gamedata
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
+		if (IsClientInGame(iClient))
+			g_iAllowPlayerClass[iClient]++;
 	
 	if (0 < iAttacker <= MaxClients)
 	{
-		g_iAllowPlayerClass[iAttacker]++;
-		
 		if (iWeapon != INVALID_ENT_REFERENCE)
 		{
 			Properties_LoadWeaponPropInt(iAttacker, iWeapon, "m_iDecapitations");
@@ -62,13 +63,14 @@ public Action Client_OnTakeDamage(int iVictim, int &iAttacker, int &iInflictor, 
 
 public void Client_OnTakeDamagePost(int iVictim, int iAttacker, int iInflictor, float flDamage, int iDamageType, int iWeapon, const float vecDamageForce[3], const float vecDamagePosition[3], int iDamageCustom)
 {
-	g_iAllowPlayerClass[iVictim]--;
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
+		if (IsClientInGame(iClient))
+			g_iAllowPlayerClass[iClient]--;
+	
 	g_bFeignDeath[iVictim] = false;
 	
 	if (0 < iAttacker <= MaxClients)
 	{
-		g_iAllowPlayerClass[iAttacker]--;
-		
 		if (iWeapon != INVALID_ENT_REFERENCE)
 		{
 			Properties_SaveWeaponPropInt(iAttacker, iWeapon, "m_iDecapitations");

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -1,3 +1,11 @@
+static char g_sPlayerCondProp[][] = {
+	"m_nPlayerCond",
+	"m_nPlayerCondEx",
+	"m_nPlayerCondEx2",
+	"m_nPlayerCondEx3",
+	"m_nPlayerCondEx4",
+};
+
 stock int TF2_CreateWeapon(int iClient, int iIndex, int iSlot)
 {
 	char sClassname[256];
@@ -571,6 +579,25 @@ stock void TF2_RemoveItem(int iClient, int iWeapon)
 	
 	RemovePlayerItem(iClient, iWeapon);
 	RemoveEntity(iWeapon);
+}
+
+stock void TF2_AddConditionFake(int iClient, TFCond nCond)
+{
+	int iCond = view_as<int>(nCond);
+	int iArray = iCond / 32;
+	int iBit = (1 << (iCond - (iArray * 32)));
+	SetEntProp(iClient, Prop_Send, g_sPlayerCondProp[iArray], GetEntProp(iClient, Prop_Send, g_sPlayerCondProp[iArray]) | iBit);
+}
+
+stock void TF2_RemoveConditionFake(int iClient, TFCond nCond)
+{
+	int iCond = view_as<int>(nCond);
+	int iArray = iCond / 32;
+	int iBit = (1 << (iCond - (iArray * 32)));
+	SetEntProp(iClient, Prop_Send, g_sPlayerCondProp[iArray], GetEntProp(iClient, Prop_Send, g_sPlayerCondProp[iArray]) & ~iBit);
+	
+	if (iArray == 0)	//Thanks legacy TF2
+		SetEntProp(iClient, Prop_Send, "_condition_bits", GetEntProp(iClient, Prop_Send, "_condition_bits") & ~iBit);
 }
 
 stock int TF2_SpawnParticle(const char[] sParticle, int iEntity)


### PR DESCRIPTION
This is more than just fixing Hitman's Heatmaker (#29), there quite a bit of code changes here.

- All of the fixes done in `CTFPlayerShared::UpdateRageBuffsAndRage`, `CTFPlayerShared::ModifyRage` and `HandleRageGain` is done in one function `Properies_CallRageMeter` to make working with it a bit easier without many dupes in each functions.
- Memory Patches now support unlimited patches in gamedata without needing to edit plugin, by just simply having name of patches `Patch_1`, `Patch_2` etc until could not find next patch number.
- Fix YER's silent kill and chargin targe meter on kill, as fix is in same function `CTFPlayer::Event_KilledOther` as Hitman's Heatmaker's fix
- Add stocks `TF2_AddConditionFake` and `TF2_RemoveConditionFake` to trick TF2 into thinking player has, or not has a cond without modifying duration of cond.