### PR TITLE
Fix cases disguise weapon not generated

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -891,7 +891,7 @@
 					}
 					"pItem"
 					{
-						"type"	"objectptr"
+						"type"	"int"
 					}
 					"b"
 					{

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -318,6 +318,8 @@ int g_iRuneCount;
 int g_iOffsetItem;
 int g_iOffsetItemDefinitionIndex;
 int g_iOffsetPlayerShared;
+int g_iOffsetDesiredDisguiseTarget;
+int g_iOffsetDisguiseCompleteTime;
 int g_iOffsetAlwaysAllow;
 
 ConVar g_cvEnabled;
@@ -331,6 +333,7 @@ TFClassType g_iClientCurrentClass[TF_MAXPLAYERS];
 bool g_bFeignDeath[TF_MAXPLAYERS];
 int g_iHypeMeterLoaded[TF_MAXPLAYERS] = {INVALID_ENT_REFERENCE, ...};
 bool g_bWeaponDecap[TF_MAXPLAYERS];
+TFClassType g_nClientDesiredDisguiseClass[TF_MAXPLAYERS] = {TFClass_Unknown, ...};
 Handle g_hTimerClientHud[TF_MAXPLAYERS];
 
 bool g_bOnTakeDamage;
@@ -381,10 +384,11 @@ public void OnPluginStart()
 	
 	delete hGameData;
 	
-	//Any weapons using m_Item would work to get offset
 	g_iOffsetItem = FindSendPropInfo("CTFWearable", "m_Item");
-	g_iOffsetItemDefinitionIndex = FindSendPropInfo("CTFWearable", "m_iItemDefinitionIndex") - g_iOffsetItem;
+	g_iOffsetItemDefinitionIndex = FindSendPropInfo("CTFWearable", "m_iItemDefinitionIndex") - g_iOffsetItem;	//Any weapons using m_Item would work to get offset
 	g_iOffsetPlayerShared = FindSendPropInfo("CTFPlayer", "m_Shared");
+	g_iOffsetDesiredDisguiseTarget = FindSendPropInfo("CTFPlayer", "m_nTeamTeleporterUsed") + 4;	// m_hDesiredDisguiseTarget
+	g_iOffsetDisguiseCompleteTime = FindSendPropInfo("CTFPlayer", "m_unTauntSourceItemID_High") + 4;	// m_flDisguiseCompleteTime
 	
 	/* This is an ugly way to get offset, but atleast it should almost never break from tf2 updates,
 	 * tf2 updating offset before all of this wouldn't break, and reports error if tf2 ever somehow broke it.

--- a/scripting/randomizer/loadout.sp
+++ b/scripting/randomizer/loadout.sp
@@ -379,6 +379,22 @@ void Loadout_ApplyClientClass(int iClient)
 
 // Weapons
 
+ArrayList Loadout_GetWeaponsFromClient(int iClient, TFClassType nClass)
+{
+	if (Group_IsClientRandomized(iClient, RandomizedType_Weapons))
+	{
+		int iPos = Group_GetClientSameInfoPos(iClient, RandomizedType_Weapons);
+		if (iPos != -1)
+			return g_eLoadoutGroup[iPos].aWeapons[nClass];
+		else
+			return g_eLoadoutClient[iClient].aWeapons[nClass];
+	}
+	else
+	{
+		return null;
+	}
+}
+
 void Loadout_RandomizeWeapon(RandomizedLoadout eLoadout)
 {
 	eLoadout.ResetWeapon();

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -139,6 +139,23 @@ public void Client_PreThink(int iClient)
 		}
 	}
 	
+	float flDisguiseCompleteTime = GetEntDataFloat(iClient, g_iOffsetDisguiseCompleteTime);
+	if (TF2_IsPlayerInCondition(iClient, TFCond_Disguising) && flDisguiseCompleteTime > 0.0 && GetGameTime() > flDisguiseCompleteTime)
+	{
+		int iTarget = TF2_GetDisguiseTarget(iClient);
+		if (iTarget != INVALID_ENT_REFERENCE)
+		{
+			SetEntDataEnt2(iClient, g_iOffsetDesiredDisguiseTarget, iTarget);
+			g_nClientDesiredDisguiseClass[iClient] = view_as<TFClassType>(GetEntProp(iClient, Prop_Send, "m_nDesiredDisguiseClass"));
+			
+			//Set disguise class to target's actual class, so disguise weapon and cosmetic can be generated for GiveNamedItem hook
+			SetEntProp(iClient, Prop_Send, "m_nDesiredDisguiseClass", TF2_GetPlayerClass(iTarget));
+			
+			//Set m_iDisguiseHealth to 0, so we can see if generated disguise weapon is from CreateDisguiseWeaponList or DetermineDisguiseWeapon
+			SetEntProp(iClient, Prop_Send, "m_iDisguiseHealth", 0);
+		}
+	}
+	
 	//PreThink have way too many IsPlayerClass check, always return true during it
 	Patch_EnableIsPlayerClass();
 	
@@ -197,6 +214,13 @@ public void Client_PreThink(int iClient)
 
 public void Client_PreThinkPost(int iClient)
 {
+	if (g_nClientDesiredDisguiseClass[iClient] != TFClass_Unknown)
+	{
+		SetEntProp(iClient, Prop_Send, "m_nDesiredDisguiseClass", g_nClientDesiredDisguiseClass[iClient]);
+		SetEntProp(iClient, Prop_Send, "m_nDisguiseClass", g_nClientDesiredDisguiseClass[iClient]);
+		g_nClientDesiredDisguiseClass[iClient] = TFClass_Unknown;
+	}
+	
 	Patch_DisableIsPlayerClass();
 	
 	//m_flEnergyDrinkMeter meant to be used for scout drinks, but TFCond_CritCola shared Buffalo Steak and Cleaner's Carbine

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -345,6 +345,42 @@ stock TFClassType TF2_GetRandomClass()
 	return view_as<TFClassType>(GetRandomInt(CLASS_MIN, CLASS_MAX));
 }
 
+stock int TF2_GetDisguiseTarget(int iClient)
+{
+	int iTarget = GetEntDataEnt2(iClient, g_iOffsetDesiredDisguiseTarget);
+	if (iTarget != INVALID_ENT_REFERENCE)
+		return iTarget;
+	
+	//Below same as CTFPlayer::TeamFortress_GetDisguiseTarget,
+	// only difference is to never disguise as ourself, cause crashes i'm not really sure why
+	int iCurrentTarget = GetEntProp(iClient, Prop_Send, "m_iDisguiseTargetIndex");
+	TFClassType nClass = view_as<TFClassType>(GetEntProp(iClient, Prop_Send, "m_nDesiredDisguiseClass"));
+	TFTeam nTeam = view_as<TFTeam>(GetEntProp(iClient, Prop_Send, "m_nDesiredDisguiseTeam"));
+	
+	ArrayList aPossibleTargets = new ArrayList();
+	for (int i = 1; i <= MaxClients; i++)
+	{
+		if (i != iClient && i != iCurrentTarget && IsClientInGame(i) && TF2_GetPlayerClass(i) == nClass && TF2_GetClientTeam(i) == nTeam)
+			aPossibleTargets.Push(i);
+	}
+	
+	if (aPossibleTargets.Length == 0)
+	{
+		for (int i = 1; i <= MaxClients; i++)
+		{
+			if (i != iClient && IsClientInGame(i) && TF2_GetClientTeam(i) == nTeam)
+				aPossibleTargets.Push(i);
+		}
+	}
+	
+	int iCount = aPossibleTargets.Length;
+	if (iCount > 0)
+		iTarget = aPossibleTargets.Get(GetRandomInt(0, iCount - 1));
+	
+	delete aPossibleTargets;
+	return iTarget;
+}
+
 stock int TF2_GetSapper(int iObject)
 {
 	if (!GetEntProp(iObject, Prop_Send, "m_bHasSapper"))


### PR DESCRIPTION
Fixes #26.
If player disguises as target/class they'd normally get default weapons, weapon based on target if playing as disguised class is generated instead. This is so that disguised weapon respects whatever convar `randomizer_weapons` is.