### PR TITLE
Attempt improve lags from weapon generation

### DIFF
--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -487,7 +487,9 @@ stock void TF2_RemoveItem(int iClient, int iWeapon)
 		TF2_RemoveWearable(iClient, iExtraWearable);
 	
 	RemovePlayerItem(iClient, iWeapon);
-	RemoveEntity(iWeapon);
+	
+	//Add to list to remove later instead of removing all weapons at once
+	g_aEntityToRemove.Push(EntIndexToEntRef(iWeapon));
 }
 
 stock void TF2_AddConditionFake(int iClient, TFCond nCond)


### PR DESCRIPTION
I have this branch here for a while, but never bothered to do a proper test and merge it until then.

It attempts to lower lag-spikes from weapon generation/deletion by only generate/delete one on every frame instead of doing all in one frame when possible.