### PR TITLE
Improve lags on getting wearables

### DIFF
--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -321,6 +321,7 @@ bool g_bTF2Items;
 bool g_bAllowGiveNamedItem;
 int g_iRuneCount;
 int g_iOffsetItemDefinitionIndex;
+int g_iOffsetMyWearables;
 int g_iOffsetPlayerShared;
 int g_iOffsetAlwaysAllow;
 
@@ -392,6 +393,7 @@ public void OnPluginStart()
 	
 	//Any weapons using m_Item would work to get offset
 	g_iOffsetItemDefinitionIndex = FindSendPropInfo("CTFWearable", "m_iItemDefinitionIndex") - FindSendPropInfo("CTFWearable", "m_Item");
+	g_iOffsetMyWearables = FindSendPropInfo("CTFPlayer", "m_hMyWearables");
 	g_iOffsetPlayerShared = FindSendPropInfo("CTFPlayer", "m_Shared");
 	
 	/* This is an ugly way to get offset, but atleast it should almost never break from tf2 updates,

--- a/scripting/randomizer/loadout.sp
+++ b/scripting/randomizer/loadout.sp
@@ -709,20 +709,21 @@ void Loadout_ApplyClientCosmetics(int iClient, const int[] iSlots, int iSlotCoun
 	g_eLoadoutClient[iClient].iCurrentCosmeticId = g_eLoadoutClient[iClient].iNextCosmeticId;
 	
 	//Destroy any cosmetics left
-	int iCosmetic;
-	while ((iCosmetic = FindEntityByClassname(iCosmetic, "tf_wearable*")) > MaxClients)
+	int iWearableCount = TF2_GetWearableCount(iClient);
+	for (int i = 0; i < iWearableCount; i++)
 	{
-		if (GetEntPropEnt(iCosmetic, Prop_Send, "m_hOwnerEntity") == iClient)
+		int iWearable = TF2_GetWearable(iClient, i);
+		if (iWearable == INVALID_ENT_REFERENCE)
+			continue;
+		
+		int iIndex = GetEntProp(iWearable, Prop_Send, "m_iItemDefinitionIndex");
+		for (int iClass = CLASS_MIN; iClass <= CLASS_MAX; iClass++)
 		{
-			int iIndex = GetEntProp(iCosmetic, Prop_Send, "m_iItemDefinitionIndex");
-			for (int iClass = CLASS_MIN; iClass <= CLASS_MAX; iClass++)
+			int iSlot = TF2_GetSlotFromIndex(iIndex, view_as<TFClassType>(iClass));
+			if (iSlot == LoadoutSlot_Misc)
 			{
-				int iSlot = TF2_GetSlotFromIndex(iIndex, view_as<TFClassType>(iClass));
-				if (iSlot == LoadoutSlot_Misc)
-				{
-					TF2_RemoveItem(iClient, iCosmetic);
-					continue;
-				}
+				TF2_RemoveItem(iClient, iWearable);
+				continue;
 			}
 		}
 	}

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -212,6 +212,7 @@ stock bool TF2_GetItem(int iClient, int &iWeapon, int &iPos, bool bCosmetic = fa
 	
 	//No more weapons to loop
 	iWeapon = INVALID_ENT_REFERENCE;
+	iPos = 0;
 	return false;
 }
 


### PR DESCRIPTION
This probably won't drastically lower lags, but still a improvement anyway. Thanks to SM 1.11, we can get the offset of `CTFPlayer::m_hMyWearables` to directly get wearables through this without needing to loop through every existing wearables.