### PR TITLE
Remove config to set robot arm viewmodel

### DIFF
--- a/configs/randomizer/viewmodels.cfg
+++ b/configs/randomizer/viewmodels.cfg
@@ -23,13 +23,4 @@
 		"tf_weapon_medigun"			"demoman"
 		"tf_weapon_medigun"			"heavy"
 	}
-	
-	"RobotArm"
-	{
-		"tf_weapon_raygun"			"sniper"
-		"tf_weapon_rocketpack"		"sniper"
-		"tf_weapon_fists"			"sniper"
-		"tf_weapon_grapplinghook"	"sniper"
-		"tf_weapon_spellbook"		"sniper"
-	}
 }

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -861,9 +861,6 @@ public MRESReturn DHook_ForceRespawnPre(int iClient)
 		if (GetEntPropEnt(iBuilding, Prop_Send, "m_hBuilder") == iClient)
 			SDKCall_RemoveObject(iClient, iBuilding);
 	
-	//Check if robot arm need to be changed before setting class
-	ViewModels_CheckRobotArm(iClient);
-	
 	if (Group_IsClientRandomized(iClient, RandomizedType_Class))
 	{
 		TFClassType nClass = Loadout_GetClientClass(iClient);

--- a/scripting/randomizer/loadout.sp
+++ b/scripting/randomizer/loadout.sp
@@ -286,9 +286,6 @@ void Loadout_RefreshClient(int iClient)
 	
 	Loadout_UpdateClientInfo(iClient);
 	
-	//Check if robot arm need to be changed before setting class
-	ViewModels_CheckRobotArm(iClient);
-	
 	for (RandomizedType nType; nType < RandomizedType_MAX; nType++)
 	{
 		if (Group_IsClientRandomized(iClient, nType))

--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -266,9 +266,6 @@ public void Client_WeaponEquipPost(int iClient, int iWeapon)
 {
 	RevertClientClass(iClient);
 	
-	//Give robot arm viewmodel if weapon isnt good with current viewmodel
-	ViewModels_CheckRobotArm(iClient);
-	
 	//Refresh controls and huds
 	Controls_RefreshClient(iClient);
 	Huds_RefreshClient(iClient);

--- a/scripting/randomizer/viewmodels.sp
+++ b/scripting/randomizer/viewmodels.sp
@@ -47,12 +47,10 @@ methodmap WeaponClassList < StringMap
 }
 
 static WeaponClassList g_mViewModelsInvisible;
-static WeaponClassList g_mViewModelsRobotArm;
 
 void ViewModels_Init()
 {
 	g_mViewModelsInvisible = new WeaponClassList();
-	g_mViewModelsRobotArm = new WeaponClassList();
 }
 
 void ViewModels_Refresh()
@@ -62,7 +60,6 @@ void ViewModels_Refresh()
 		return;
 	
 	g_mViewModelsInvisible.Load(kv, "Invisible");
-	g_mViewModelsRobotArm.Load(kv, "RobotArm");
 	
 	delete kv;
 }
@@ -96,22 +93,4 @@ void ViewModels_DisableInvisible(int iWeapon)
 {
 	SetEntityRenderMode(iWeapon, RENDER_NORMAL); 
 	SetEntityRenderColor(iWeapon, 255, 255, 255, 255);
-}
-
-void ViewModels_CheckRobotArm(int iClient)
-{
-	TFClassType nClass = TF2_GetPlayerClass(iClient);
-	int iWeapon, iPos;
-	while (TF2_GetItem(iClient, iWeapon, iPos))
-	{
-		bool bCurrentRobotArm = g_mViewModelsRobotArm.Exists(iWeapon, nClass);
-		bool bNextRobotArm = bCurrentRobotArm;
-		if (Group_IsClientRandomized(iClient, RandomizedType_Class))
-			bNextRobotArm = g_mViewModelsRobotArm.Exists(iWeapon, Loadout_GetClientClass(iClient));
-		
-		if (bNextRobotArm)	//Should have one
-			TF2Attrib_SetByName(iWeapon, "mod wrench builds minisentry", 1.0);
-		else if (bCurrentRobotArm)	//Currently have robot arm but shouldn't have one for new class
-			TF2Attrib_RemoveByName(iWeapon, "mod wrench builds minisentry");
-	}
 }


### PR DESCRIPTION
This RobotArm config was added at #38 to fix crashes from sniper using some weapon viewmodels, but TF2's 29/07/2022 update fixes this crash, making RobotArm workaround fix no longer needed.