### PR TITLE
fix viewmodels

### DIFF
--- a/scripting/randomizer/sdkhook.sp
+++ b/scripting/randomizer/sdkhook.sp
@@ -252,11 +252,6 @@ public Action Client_WeaponEquip(int iClient, int iWeapon)
 {
 	SetEntPropEnt(iWeapon, Prop_Send, "m_hOwnerEntity", iClient);	//So client's class can be attempted first for TF2_GetDefaultClassFromItem
 	
-	ViewModels_UpdateArms(iClient, iWeapon);	// Set arms for the weapon were about to equip
-	
-	//Change class before equipping the weapon, otherwise anims and reload times are odd
-	SetClientClass(iClient, TF2_GetDefaultClassFromItem(iWeapon));
-	
 	// Don't allow robotarm model screw up anims
 	if (TF2Attrib_HookValueFloat(0.0, "wrench_builds_minisentry", iClient) == 1.0)
 		TF2Attrib_SetByName(iClient, "mod wrench builds minisentry", -1.0);	// 1.0 + -1.0 = 0.0
@@ -268,8 +263,6 @@ public void Client_WeaponEquipPost(int iClient, int iWeapon)
 {
 	TF2Attrib_RemoveByName(iClient, "mod wrench builds minisentry");
 	
-	RevertClientClass(iClient);
-	
 	ViewModels_UpdateArms(iClient);
 	
 	//Refresh controls and huds
@@ -279,8 +272,6 @@ public void Client_WeaponEquipPost(int iClient, int iWeapon)
 
 public Action Client_WeaponSwitch(int iClient, int iWeapon)
 {
-	ViewModels_UpdateArms(iClient);	// Incase if weapons were to be not properly set up yet for draw animation
-	
 	//Save current active weapon properties before potentally switched out
 	Properties_SaveActiveWeaponAmmo(iClient);
 	

--- a/scripting/randomizer/viewmodels.sp
+++ b/scripting/randomizer/viewmodels.sp
@@ -76,9 +76,16 @@ void ViewModels_UpdateArms(int iClient, int iForceWeapon = INVALID_ENT_REFERENCE
 		else
 			sModel = g_sViewModelsArms[nClass];
 		
-		int iModelIndex = GetModelIndex(sModel);
-		if (GetEntProp(iViewModel, Prop_Send, "m_nModelIndex") != iModelIndex)
-			SetEntProp(iViewModel, Prop_Send, "m_nModelIndex", iModelIndex);
+		if(iActiveWeapon != INVALID_ENT_REFERENCE)
+		{
+			SetEntityModel(iActiveWeapon, sModel);
+			SetEntProp(iActiveWeapon, Prop_Send, "m_nCustomViewmodelModelIndex", GetEntProp(iActiveWeapon, Prop_Send, "m_nModelIndex"));
+			SetEntProp(iActiveWeapon, Prop_Send, "m_iViewModelIndex", GetEntProp(iActiveWeapon, Prop_Send, "m_nModelIndex"));
+		}
+		
+		//int iModelIndex = GetModelIndex(sModel);
+		//if (GetEntProp(iViewModel, Prop_Send, "m_nModelIndex") != iModelIndex)
+		//	SetEntProp(iViewModel, Prop_Send, "m_nModelIndex", iModelIndex);
 	}
 	
 	int iArmsModelIndex = GetModelIndex(g_sViewModelsArms[TF2_GetPlayerClass(iClient)]);
@@ -100,14 +107,6 @@ void ViewModels_UpdateArms(int iClient, int iForceWeapon = INVALID_ENT_REFERENCE
 		
 		SetEntPropEnt(iArms, Prop_Send, "m_hWeaponAssociatedWith", iActiveWeapon);
 		SetEntPropEnt(iWearable, Prop_Send, "m_hWeaponAssociatedWith", iActiveWeapon);
-	}
-	
-	int iMaxWeapons = GetMaxWeapons();
-	for (int i = 0; i < iMaxWeapons; i++)
-	{
-		int iWeapon = GetEntPropEnt(iClient, Prop_Send, "m_hMyWeapons", i);
-		if (iWeapon != INVALID_ENT_REFERENCE)
-			SetEntProp(iWeapon, Prop_Send, "m_nCustomViewmodelModelIndex", GetEntProp(iWeapon, Prop_Send, "m_nModelIndex"));
 	}
 }
 


### PR DESCRIPTION
Changing the player's class to the intended weapon's class and then reverting it back is not required to have correct animations. The missing piece was setting the weapon's `m_iViewModelIndex`.