### PR TITLE
Redo patches to be more robust

### DIFF
--- a/gamedata/randomizer.txt
+++ b/gamedata/randomizer.txt
@@ -4,51 +4,6 @@
 	{
 		"Keys"
 		{
-			"PatchReplace_01"	//Demoman class check for eyelander health
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
-			}
-			"PatchReplace_02"	//Demoman class check for eyelander speed and charging
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
-			}
-			"PatchReplace_03"	//Medic class check for healing charging
-			{
-				"linux"		"\x90\x90\x90\x90\x90\x90"	// Replace 'jnz' to NOP (skip)
-				"windows"	"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to NOP (skip)
-			}
-			"PatchReplace_04"	//Medic class check for Overdose speed
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
-			}
-			"PatchReplace_05"	//Heavy class check for steak speed
-			{
-				"linux"		"\x90\x90\x90\x90\x90\x90"	// Replace 'jz' (if '==' jump) to to NOP (skip)
-				"windows"	"\xEB"	// Replace 'jnz short' to 'jmp short' (always jump)
-			}
-			"PatchReplace_06"	//Scout class check for Baby Face Blaster and Crit-A-Cola speed
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
-			}
-			"PatchReplace_07"	//Spy class check for Your Eternal Reward silent kill
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
-			}
-			"PatchReplace_08"	//Demoman class check for kill refilling meter
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90\x90\x90\x90\x90"	// Replace 'jnz' to NOP (skip)
-			}
-			"PatchReplace_09"	//Sniper class check for Hitman's Heatmaker rage on kill
-			{
-				"linux"		"\x90\xE9"	// Replace 'jz' (if '==' jump) to 'jmp' (always jump)
-				"windows"	"\x90\x90"	// Replace 'jnz short' to NOP (skip)
-			}
 			"PatchReplace_IsPlayerClass"	//Given class check, this patch makes it always return true
 			{
 				// \xB8\x01\x00\x00\x00                            mov     eax, 1
@@ -59,77 +14,24 @@
 				// \x90                                            nop
 				"windows"	"\xB8\x01\x00\x00\x00\x90"
 			}
+			
+			"PatchSearch_Speed01"
+			{
+				"linux"		"\x83\xFF\x2A\x0F"
+				"windows"	"\x83\x7D\xEC\x2A"
+			}
+			
+			"PatchSearch_Speed02"
+			{
+				"windows"	"\x83\xF8\x2A"
+			}
+			
+			"PatchCount_Speed"	"6"		// How many patches we should expect from searches, errors out if found different amount of it
+			"PatchBits_Speed"	"1800"	// How many bits to read from start to function to collect address
+			"PatchWildcard_Speed"	"\x01\x04\x05\x06"	// List of possible values from \x2A wildcard to consider it valid and replace it
 		}
 		"Addresses"
 		{
-			"PatchSig_01"
-			{
-				"signature" "PatchSig_01"
-				"linux"
-				{
-					"offset"	"95"
-				}
-				"windows"
-				{
-					"offset"	"7"	//Start is pushed back by 7 to make good unique sig
-				}
-			}
-			"PatchSig_02"
-			{
-				"signature" "PatchSig_02"
-			}
-			"PatchSig_03"
-			{
-				"signature" "PatchSig_03"
-				"linux"
-				{
-					"offset"	"3"	//Start is pushed back by 3 to make good unique sig
-				}
-			}
-			"PatchSig_04"
-			{
-				"signature" "PatchSig_04"
-			}
-			"PatchSig_05"
-			{
-				"signature" "PatchSig_05"
-			}
-			"PatchSig_06"
-			{
-				"signature" "PatchSig_06"
-				"linux"
-				{
-					"offset"	"3"	//Start is pushed back by 3 to make good unique sig
-				}
-			}
-			"PatchSig_07"
-			{
-				"signature" "PatchSig_07"
-				"linux"
-				{
-					"offset"	"649"
-				}
-				"windows"
-				{
-					"offset"	"4"	//Start is pushed back by 4 to make good unique sig
-				}
-			}
-			"PatchSig_08"
-			{
-				"signature" "PatchSig_08"
-				"windows"
-				{
-					"offset"	"4"	//Start is pushed back by 4 to make good unique sig
-				}
-			}
-			"PatchSig_09"
-			{
-				"signature" "PatchSig_09"
-				"linux"
-				{
-					"offset"	"1890"
-				}
-			}
 			"PatchSig_IsPlayerClass"
 			{
 				"signature" "PatchSig_IsPlayerClass"
@@ -145,51 +47,6 @@
 		}
 		"Signatures"
 		{
-			"PatchSig_01"	//CTFPlayer::GetMaxHealthForBuffing
-			{
-				"linux"		"@_ZN9CTFPlayer22GetMaxHealthForBuffingEv"
-				"windows"	"\x83\xBF\x2A\x2A\x2A\x2A\x04\x75\x2A\x6A\x00"
-			}
-			"PatchSig_02"	//CTFPlayer::TeamFortress_CalculateMaxSpeed
-			{
-				"linux"		"\x0F\x84\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x80\xB8\x2A\x0C\x00\x00\x00\x75\x2A\x80\xBB\x2A\x1E\x00\x00\x00"
-				"windows"	"\x75\x2A\x6A\x00\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x6A\x00\x6A\x40\x8B\xCE"
-			}
-			"PatchSig_03"	//CTFPlayer::TeamFortress_CalculateMaxSpeed
-			{
-				"linux"		"\x83\xFF\x05\x0F\x85\x2A\x2A\x2A\x2A"
-				"windows"	"\x0F\x85\x2A\x2A\x2A\x2A\x85\xDB\x0F\x84\x2A\x2A\x2A\x2A\x6A\x00"
-			}
-			"PatchSig_04"	//CTFPlayer::TeamFortress_CalculateMaxSpeed
-			{
-				"linux"		"\x0F\x84\x2A\x2A\x2A\x2A\x83\xEC\x0C\x6A\x01\x6A\x00\xFF\x75\xD8"
-				"windows"	"\x75\x2A\x6A\x00\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x6A\x00\x6A\x32"
-			}
-			"PatchSig_05"	//CTFPlayer::TeamFortress_CalculateMaxSpeed
-			{
-				"linux"		"\x0F\x84\x2A\x2A\x2A\x2A\x83\xFF\x01\x0F\x84\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x85\xC0"
-				"windows"	"\x75\x2A\xF3\x0F\x10\x45\xE8\x8B\xCF"
-			}
-			"PatchSig_06"	//CTFPlayer::TeamFortress_CalculateMaxSpeed
-			{
-				"linux"		"\x83\xFF\x01\x0F\x84\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x85\xC0"
-				"windows"	"\x75\x2A\x6A\x55\x8B\xCE\xE8\x2A\x2A\x2A\x2A\x85\xC0"
-			}
-			"PatchSig_07"	//CTFPlayer::Event_KilledOther
-			{
-				"linux"		"@_ZN9CTFPlayer17Event_KilledOtherEP11CBaseEntityRK15CTakeDamageInfo"
-				"windows"	"\x83\x78\x04\x08\x75\x2A\x56"
-			}
-			"PatchSig_08"	//CTFPlayer::Event_KilledOther
-			{
-				"linux"		"\x0F\x84\x2A\x2A\x2A\x2A\x83\xF8\x02\x0F\x84\x2A\x2A\x2A\x2A\x8B\x83\x2A\x2A\x2A\x2A"
-				"windows"	"\x83\x78\x04\x04\x0F\x85\x2A\x2A\x2A\x2A"
-			}
-			"PatchSig_09"	//CTFPlayer::Event_KilledOther
-			{
-				"linux"		"@_ZN9CTFPlayer17Event_KilledOtherEP11CBaseEntityRK15CTakeDamageInfo"
-				"windows"	"\x75\x2A\xD9\xEE\x6A\x01\x6A\x00\x53"
-			}
 			"PatchSig_IsPlayerClass"	//CTFPlayer::IsPlayerClass
 			{
 				"linux"		"@_ZNK9CTFPlayer13IsPlayerClassEi"
@@ -388,6 +245,11 @@
 				"linux"		"69"
 				"windows"	"68"
 			}
+			"CBaseEntity::Event_KilledOther"
+			{
+				"linux"		"70"
+				"windows"	"69"
+			}
 			"CBaseEntity::GetMaxHealth"
 			{
 				"linux"		"123"
@@ -418,6 +280,16 @@
 				"linux"		"486"
 				"windows"	"479"
 			}
+			"CTFSword::GetSwordSpeedMod"
+			{
+				"linux"		"492"
+				"windows"	"484"
+			}
+			"CTFSword::GetSwordHealthMod"
+			{
+				"linux"		"493"
+				"windows"	"485"
+			}
 			"CBaseObject::Killed"
 			{
 				"linux"		"356"
@@ -432,6 +304,11 @@
 			{
 				"linux"		"337"
 				"windows"	"336"
+			}
+			"CBasePlayer::ClientCommand"
+			{
+				"linux"		"380"
+				"windows"	"379"
 			}
 			"CBasePlayer::EquipWearable"
 			{
@@ -448,10 +325,10 @@
 				"linux"		"277"
 				"windows"	"276"
 			}
-			"CTFPlayer::ClientCommand"
+			"CBaseMultiplayerPlayer::SpeakConceptIfAllowed"
 			{
-				"linux"		"380"
-				"windows"	"379"
+				"linux"		"473"
+				"windows"	"472"
 			}
 			"CTFPlayer::GiveNamedItem"
 			{
@@ -467,6 +344,16 @@
 			{
 				"linux"		"16"
 				"windows"	"15"
+			}
+			"CTakeDamageInfo::m_bitsDamageType"
+			{
+				"linux"		"60"
+				"windows"	"60"
+			}
+			"CTakeDamageInfo::m_iDamageCustom"
+			{
+				"linux"		"64"
+				"windows"	"64"
 			}
 		}
 		"Functions"
@@ -821,6 +708,24 @@
 					}
 				}
 			}
+			"CBaseEntity::Event_KilledOther"
+			{
+				"offset"	"CBaseEntity::Event_KilledOther"
+				"hooktype"	"entity"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"pVictim"
+					{
+						"type"	"cbaseentity"
+					}
+					"info"
+					{
+						"type"    "objectptr"
+					}
+				}
+			}
 			"CEconEntity::TranslateViewmodelHandActivityInternal"
 			{
 				"offset"	"CEconEntity::TranslateViewmodelHandActivityInternal"
@@ -870,6 +775,20 @@
 					}
 				}
 			}
+			"CTFSword::GetSwordSpeedMod"
+			{
+				"offset"	"CTFSword::GetSwordSpeedMod"
+				"hooktype"	"entity"
+				"return"	"float"
+				"this"		"entity"
+			}
+			"CTFSword::GetSwordHealthMod"
+			{
+				"offset"	"CTFSword::GetSwordHealthMod"
+				"hooktype"	"entity"
+				"return"	"int"
+				"this"		"entity"
+			}
 			"CBaseObject::Killed"
 			{
 				"offset"	"CBaseObject::Killed"
@@ -908,6 +827,20 @@
 				"return"	"void"
 				"this"		"entity"
 			}
+			"CBasePlayer::ClientCommand"
+			{
+				"offset"	"CBasePlayer::ClientCommand"
+				"hooktype"	"entity"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"pArgs"
+					{
+						"type"	"objectptr"
+					}
+				}
+			}
 			"CBasePlayer::EquipWearable"
 			{
 				"offset"	"CBasePlayer::EquipWearable"
@@ -936,17 +869,33 @@
 					}
 				}
 			}
-			"CTFPlayer::ClientCommand"
+			"CBaseMultiplayerPlayer::SpeakConceptIfAllowed"
 			{
-				"offset"	"CTFPlayer::ClientCommand"
+				"offset"	"CBaseMultiplayerPlayer::SpeakConceptIfAllowed"
 				"hooktype"	"entity"
 				"return"	"bool"
 				"this"		"entity"
 				"arguments"
 				{
-					"pArgs"
+					"iConcept"
 					{
-						"type"	"objectptr"
+						"type"	"int"
+					}
+					"modifiers"
+					{
+						"type"	"charptr"
+					}
+					"pszOutResponseChosen"
+					{
+						"type"	"charptr"
+					}
+					"bufsize"
+					{
+						"type"	"int"
+					}
+					"filter"
+					{
+						"type"	"int"
 					}
 				}
 			}

--- a/scripting/randomizer.sp
+++ b/scripting/randomizer.sp
@@ -15,7 +15,7 @@
 
 #pragma newdecls required
 
-#define PLUGIN_VERSION			"1.10.4"
+#define PLUGIN_VERSION			"1.11.0"
 #define PLUGIN_VERSION_REVISION	"manual"
 
 #define CONFIG_MAXCHAR	64
@@ -34,6 +34,12 @@
 
 #define PARTICLE_BEAM_BLU	"medicgun_beam_blue"
 #define PARTICLE_BEAM_RED	"medicgun_beam_red"
+
+// from mp_shareddefs.h
+const int MP_CONCEPT_KILLED_PLAYER = 7;
+
+// from tf_shareddef.h
+#define DMG_MELEE								(DMG_BLAST_SURFACE)
 
 // entity effects
 enum
@@ -322,6 +328,9 @@ bool g_bEnabled;
 bool g_bTF2Items;
 bool g_bAllowGiveNamedItem;
 int g_iRuneCount;
+
+int g_iOffsetDamageType;
+int g_iOffsetDamageCustom;
 int g_iOffsetItem;
 int g_iOffsetItemDefinitionIndex;
 int g_iOffsetMyWearables;
@@ -394,6 +403,9 @@ public void OnPluginStart()
 	Patch_Init(hGameData);
 	DHook_Init(hGameData);
 	SDKCall_Init(hGameData);
+	
+	g_iOffsetDamageType = hGameData.GetOffset("CTakeDamageInfo::m_bitsDamageType");
+	g_iOffsetDamageCustom = hGameData.GetOffset("CTakeDamageInfo::m_iDamageCustom");
 	
 	delete hGameData;
 	
@@ -713,7 +725,6 @@ public void OnEntityDestroyed(int iEntity)
 void EnableRandomizer()
 {
 	g_bEnabled = true;
-	Patch_Enable();
 	
 	DHook_EnableDetour();
 	DHook_HookGamerules();
@@ -742,7 +753,7 @@ void DisableRandomizer()
 	DHook_DisableDetour();
 	DHook_UnhookGamerules();
 	
-	Patch_Disable();
+	Patch_RevertSpeed();
 	g_bEnabled = false;
 	
 	ViewModels_RemoveAll();

--- a/scripting/randomizer/dhook.sp
+++ b/scripting/randomizer/dhook.sp
@@ -1147,6 +1147,8 @@ public MRESReturn DHook_SpeakConceptIfAllowedPre(int iClient, DHookReturn hRetur
 	if (iConcept == MP_CONCEPT_KILLED_PLAYER)
 	{
 		int iActiveWeapon = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
+		if (iActiveWeapon == INVALID_ENT_REFERENCE)
+			return MRES_Ignored;
 		
 		int iMode;
 		TF2Attrib_HookValueInt(iMode, "set_weapon_mode", iActiveWeapon);

--- a/scripting/randomizer/sdkcall.sp
+++ b/scripting/randomizer/sdkcall.sp
@@ -1,3 +1,5 @@
+const SDKType SDKType_Unknown = view_as<SDKType>(-1);
+
 static Handle g_hSDKGetMaxAmmo;
 static Handle g_hSDKAddObject;
 static Handle g_hSDKRemoveObject;
@@ -12,144 +14,67 @@ static Handle g_hSDKHandleRageGain;
 static Handle g_hSDKSetItem;
 static Handle g_hSDKGetBaseEntity;
 static Handle g_hSDKGetMaxHealth;
+static Handle g_hSDKGetSwordHealthMod;
 static Handle g_hSDKWeaponCanSwitchTo;
 static Handle g_hSDKEquipWearable;
 static Handle g_hSDKGiveNamedItem;
 
 public void SDKCall_Init(GameData hGameData)
 {
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::GetMaxAmmo");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	g_hSDKGetMaxAmmo = EndPrepSDKCall();
-	if (!g_hSDKGetMaxAmmo)
-		LogMessage("Failed to create call: CTFPlayer::GetMaxAmmo");
+	g_hSDKGetMaxAmmo = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Signature, "CTFPlayer::GetMaxAmmo", SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData);
+	g_hSDKAddObject = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Signature, "CTFPlayer::AddObject", _, SDKType_CBaseEntity);
+	g_hSDKRemoveObject = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Signature, "CTFPlayer::RemoveObject", _, SDKType_CBaseEntity);
+	g_hSDKDoClassSpecialSkill = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Signature, "CTFPlayer::DoClassSpecialSkill", SDKType_Bool);
+	g_hSDKEndClassSpecialSkill = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Signature, "CTFPlayer::EndClassSpecialSkill", SDKType_Bool);
+	g_hSDKGetLoadoutItem = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Signature, "CTFPlayer::GetLoadoutItem", SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData);
+	g_hSDKRollNewSpell = SDKCall_Create(hGameData, SDKCall_Entity, SDKConf_Signature, "CTFSpellBook::RollNewSpell", _, SDKType_PlainOldData, SDKType_Bool);
+	g_hSDKUpdateRageBuffsAndRage = SDKCall_Create(hGameData, SDKCall_Raw, SDKConf_Signature, "CTFPlayerShared::UpdateRageBuffsAndRage");
+	g_hSDKModifyRage = SDKCall_Create(hGameData, SDKCall_Raw, SDKConf_Signature, "CTFPlayerShared::ModifyRage", _, SDKType_Float);
+	g_hSDKSetCarryingRuneType = SDKCall_Create(hGameData, SDKCall_Raw, SDKConf_Signature, "CTFPlayerShared::SetCarryingRuneType", _, SDKType_PlainOldData);
+	g_hSDKHandleRageGain = SDKCall_Create(hGameData, SDKCall_Static, SDKConf_Signature, "HandleRageGain", _, SDKType_CBaseEntity, SDKType_PlainOldData, SDKType_Float, SDKType_Float);
+	g_hSDKSetItem = SDKCall_Create(hGameData, SDKCall_Raw, SDKConf_Signature, "CEconItemView::operator=", SDKType_PlainOldData, SDKType_PlainOldData);
+	g_hSDKGetBaseEntity = SDKCall_Create(hGameData, SDKCall_Raw, SDKConf_Virtual, "CBaseEntity::GetBaseEntity", SDKType_CBaseEntity);
+	g_hSDKGetMaxHealth = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Virtual, "CBaseEntity::GetMaxHealth", SDKType_PlainOldData);
+	g_hSDKGetSwordHealthMod = SDKCall_Create(hGameData, SDKCall_Entity, SDKConf_Virtual, "CTFSword::GetSwordHealthMod", SDKType_PlainOldData);
+	g_hSDKWeaponCanSwitchTo = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Virtual, "CBaseCombatCharacter::Weapon_CanSwitchTo", SDKType_Bool, SDKType_CBaseEntity);
+	g_hSDKEquipWearable = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Virtual, "CBasePlayer::EquipWearable", _, SDKType_CBaseEntity);
+	g_hSDKGiveNamedItem = SDKCall_Create(hGameData, SDKCall_Player, SDKConf_Virtual, "CTFPlayer::GiveNamedItem", SDKType_CBaseEntity, SDKType_String, SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData);
+}
+
+static Handle SDKCall_Create(GameData hGameData, SDKCallType nType, SDKFuncConfSource nSource, const char[] sName, SDKType nReturn = SDKType_Unknown, SDKType nParam1 = SDKType_Unknown, SDKType nParam2 = SDKType_Unknown, SDKType nParam3 = SDKType_Unknown, SDKType nParam4 = SDKType_Unknown)
+{
+	StartPrepSDKCall(nType);
+	PrepSDKCall_SetFromConf(hGameData, nSource, sName);
 	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::AddObject");
-	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKAddObject = EndPrepSDKCall();
-	if (!g_hSDKAddObject)
-		LogError("Failed to create call: CTFPlayer::AddObject");
+	SDKCall_AddParameter(nParam1);
+	SDKCall_AddParameter(nParam2);
+	SDKCall_AddParameter(nParam3);
+	SDKCall_AddParameter(nParam4);
 	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::RemoveObject");
-	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKRemoveObject = EndPrepSDKCall();
-	if (!g_hSDKRemoveObject)
-		LogError("Failed to create call: CTFPlayer::RemoveObject");
+	if (nReturn != SDKType_Unknown)
+	{
+		if (nReturn == SDKType_String || nReturn == SDKType_CBaseEntity)
+			PrepSDKCall_SetReturnInfo(nReturn, SDKPass_Pointer);
+		else
+			PrepSDKCall_SetReturnInfo(nReturn, SDKPass_ByValue);
+	}
 	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::DoClassSpecialSkill");
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
-	g_hSDKDoClassSpecialSkill = EndPrepSDKCall();
-	if (!g_hSDKDoClassSpecialSkill)
-		LogError("Failed to create call: CTFPlayer::DoClassSpecialSkill");
+	Handle hSDKCall = EndPrepSDKCall();
+	if (!hSDKCall)
+		LogError("Failed to create call: %s", sName);
 	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::EndClassSpecialSkill");
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
-	g_hSDKEndClassSpecialSkill = EndPrepSDKCall();
-	if (!g_hSDKEndClassSpecialSkill)
-		LogError("Failed to create call: CTFPlayer::EndClassSpecialSkill");
+	return hSDKCall;
+}
+
+static void SDKCall_AddParameter(SDKType nParam)
+{
+	if (nParam == SDKType_Unknown)
+		return;
 	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::GetLoadoutItem");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
-	g_hSDKGetLoadoutItem = EndPrepSDKCall();
-	if (!g_hSDKGetLoadoutItem)
-		LogError("Failed to create call: CTFPlayer::GetLoadoutItem");
-	
-	StartPrepSDKCall(SDKCall_Entity);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFSpellBook::RollNewSpell");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_ByValue);
-	g_hSDKRollNewSpell = EndPrepSDKCall();
-	if (!g_hSDKRollNewSpell)
-		LogError("Failed to create call: CTFSpellBook::RollNewSpell");
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayerShared::UpdateRageBuffsAndRage");
-	g_hSDKUpdateRageBuffsAndRage = EndPrepSDKCall();
-	if (!g_hSDKUpdateRageBuffsAndRage)
-		LogError("Failed to create call: CTFPlayerShared::UpdateRageBuffsAndRage");
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayerShared::ModifyRage");
-	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
-	g_hSDKModifyRage = EndPrepSDKCall();
-	if (!g_hSDKModifyRage)
-		LogError("Failed to create call: CTFPlayerShared::ModifyRage");
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayerShared::SetCarryingRuneType");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	g_hSDKSetCarryingRuneType = EndPrepSDKCall();
-	if (!g_hSDKSetCarryingRuneType)
-		LogError("Failed to create call: CTFPlayerShared::SetCarryingRuneType");
-	
-	StartPrepSDKCall(SDKCall_Static);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "HandleRageGain");
-	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);	// unsigned int
-	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
-	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
-	g_hSDKHandleRageGain = EndPrepSDKCall();
-	if (!g_hSDKHandleRageGain)
-		LogError("Failed to create call: HandleRageGain");
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CEconItemView::operator=");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);	// CEconItemView&
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);	// CEconItemView&
-	g_hSDKSetItem = EndPrepSDKCall();
-	if (!g_hSDKSetItem)
-		LogError("Failed to create call: CEconItemView::operator=");
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBaseEntity::GetBaseEntity");
-	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKGetBaseEntity = EndPrepSDKCall();
-	if (!g_hSDKGetBaseEntity)
-		LogError("Failed to create call: CBaseEntity::GetBaseEntity");
-	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBaseEntity::GetMaxHealth");
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
-	g_hSDKGetMaxHealth = EndPrepSDKCall();
-	if (!g_hSDKGetMaxHealth)
-		LogError("Failed to create call: CBaseEntity::GetMaxHealth");
-	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBaseCombatCharacter::Weapon_CanSwitchTo");
-	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
-	g_hSDKWeaponCanSwitchTo = EndPrepSDKCall();
-	if (!g_hSDKWeaponCanSwitchTo)
-		LogError("Failed to create call: CBaseCombatCharacter::Weapon_CanSwitchTo");
-	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CBasePlayer::EquipWearable");
-	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKEquipWearable = EndPrepSDKCall();
-	if (!g_hSDKEquipWearable)
-		LogError("Failed to create call: CBasePlayer::EquipWearable");
-	
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CTFPlayer::GiveNamedItem");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKGiveNamedItem = EndPrepSDKCall();
-	if (!g_hSDKGiveNamedItem)
-		LogError("Failed to create call: CTFPlayer::GiveNamedItem");
+	if (nParam == SDKType_String || nParam == SDKType_CBaseEntity)
+		PrepSDKCall_AddParameter(nParam, SDKPass_Pointer);
+	else
+		PrepSDKCall_AddParameter(nParam, SDKPass_ByValue);
 }
 
 int SDKCall_GetMaxAmmo(int iClient, int iAmmoType, TFClassType nClass = view_as<TFClassType>(-1))
@@ -217,9 +142,14 @@ int SDKCall_GetBaseEntity(Address pEntity)
 	return SDKCall(g_hSDKGetBaseEntity, pEntity);
 }
 
-bool SDKCall_GetMaxHealth(int iEntity)
+int SDKCall_GetMaxHealth(int iEntity)
 {
 	return SDKCall(g_hSDKGetMaxHealth, iEntity);
+}
+
+int SDKCall_GetSwordHealthMod(int iSword)
+{
+	return SDKCall(g_hSDKGetSwordHealthMod, iSword);
 }
 
 bool SDKCall_WeaponCanSwitchTo(int iClient, int iWeapon)

--- a/scripting/randomizer/stocks.sp
+++ b/scripting/randomizer/stocks.sp
@@ -167,6 +167,15 @@ stock bool TF2_IndexFindAttribute(int iIndex, const char[] sAttrib, float &flVal
 	return false;
 }
 
+stock float TF2_GetAttributeValue(int iEntity, const char[] sAttrib, float flDefault)
+{
+	Address pAttrib = TF2Attrib_GetByName(iEntity, sAttrib);
+	if (pAttrib)
+		return TF2Attrib_GetValue(pAttrib);
+	else
+		return flDefault;
+}
+
 stock bool TF2_GetItem(int iClient, int &iWeapon, int &iPos, bool bCosmetic = false)
 {
 	//Could be looped through client slots, but would cause issues with >1 weapons in same slot


### PR DESCRIPTION
Patches tends to easily break from TF2 update for both windows and linux, and can be painful to maintain it. This PR updates it to try make it last worthwhile.

- `CTFPlayer::GetMaxHealthForBuffing` and `CTFPlayer::Event_KilledOther` patches are removed, replacing with hooks to manually update it. Would be insane if future TF2 were to actually edit these functions with whatever balance changes.
- `CTFPlayer::TeamFortress_CalculateMaxSpeed` patches is updated to automatically scan any of the `playerclass == TF_CLASS_*` instructions found in function, and updates `TF_CLASS_*` value to whichever class is currently at. There are safety checks that it would not attempt to patch if unexpected amount is found.
- `CTFPlayer::IsPlayerClass` patch is unchanged, it's a small function that should be simple enough to maintain it.

Also while at it, refactor dhooks and sdktools for things blah blah blah.